### PR TITLE
Remove parent from domain group.

### DIFF
--- a/src/AppBundle/Entity/Domain.php
+++ b/src/AppBundle/Entity/Domain.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -37,7 +38,7 @@ class Domain
      * @ORM\ManyToOne(targetEntity="Domain", inversedBy="subdomains", fetch="EXTRA_LAZY")
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", nullable=true, onDelete="CASCADE")
      * @ORM\Cache(usage="NONSTRICT_READ_WRITE")
-     * @Groups({"domain"})
+     * @ApiSubresource()
      */
     private $parent;
 


### PR DESCRIPTION
This causes significant performance impact because it will load the full embedded relationship of a parent, which again includes its subdomains, which will again load its parents, ... you get the picture.

Looked for a way to just force it to return the URI /api/domains/:id, but that does not seem to be an option anymore (used to be, but was removed in https://github.com/api-platform/core/pull/1696).

This feature can be enabled through Symfony starting from version 4.1, which we are not currently at.

As such, the best solutions we currently have are:
- writing our own serializer (complex and we'd mostly be reinventing the wheel)
- omitting the $parent property from the group, and instead exposing it through /api/domains/:id/parent.

Signed-off-by: Kevin Reniers <Kevin.Reniers@cegeka.com>