### PR TITLE
Process manager

### DIFF
--- a/src/Command/ProbeDispatcherCommand.php
+++ b/src/Command/ProbeDispatcherCommand.php
@@ -5,27 +5,21 @@ namespace App\Command;
 
 use App\DependencyInjection\ProbeStore;
 use App\DependencyInjection\Queue;
+use App\DependencyInjection\WorkerManager;
 use App\Instruction\Instruction;
 
 use App\Instruction\InstructionBuilder;
-use App\Kernel;
 use App\Probe\ProbeDefinition;
-
 
 use Exception;
 use Psr\Log\LoggerInterface;
 use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
-use RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Process\Exception\ProcessTimedOutException;
-use Symfony\Component\Process\InputStream;
-use Symfony\Component\Process\Process;
 
 /**
  * Class ProbeDispatcherCommand
@@ -34,20 +28,6 @@ use Symfony\Component\Process\Process;
  */
 class ProbeDispatcherCommand extends ContainerAwareCommand
 {
-    /**
-     * Indexed by process id, the processes used for workers
-     *
-     * @var Process[]
-     */
-    protected $processes = [];
-
-    /**
-     * Indexed by process id, the input streams uses to write to the process
-     *
-     * @var InputStream[]
-     */
-    private $inputStreams = [];
-
     /**
      * The number of queues that will be created by the ProbeDispatcher
      *
@@ -70,13 +50,6 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
     protected $workerLimit;
 
     /**
-     * Holds the Application Kernel
-     *
-     * @var KernelInterface
-     */
-    protected $kernel;
-
-    /**
      * Used to write to log files
      *
      * @var LoggerInterface
@@ -91,94 +64,12 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
     protected $probeStore;
 
     /**
-     * A collection of GUIDs associated with a request tracked over the course of
-     * its lifecycle
-     *
-     * @var string[]
-     */
-    private $trackingIds = [];
-
-    /**
-     * Indexed per process id, the in-memory string buffer used to hold data
-     * received from the process.
-     *
-     * @var string[]
-     */
-    private $receiveBuffers = [];
-
-    /**
-     * An array of process ids of workers that are currently idle.
-     *
-     * @var int[]
-     */
-    protected $availableWorkers = [];
-
-    /**
-     * An array of process ids of workers that are currently performing a task.
-     *
-     * @var int[]
-     */
-    protected $inUseWorkers = [];
-
-    /**
-     * The amount of workers that need to be created during the next cycle
-     *
-     * @var int
-     */
-    protected $workersNeeded;
-
-    /**
-     * The initial amount of workers to create when starting the dispatcher.
-     *
-     * @var int
-     */
-    protected $initWorkers;
-
-    /**
-     * The minimum amount of workers that should be idle at all times.
-     *
-     * @var int
-     */
-    protected $minimumIdleWorkers;
-
-    /**
-     * At most this many workers should ever be created.
-     *
-     * @var int
-     */
-    protected $maximumWorkers;
-
-    /**
-     * The threshold indicating a high amount of workers is being used, and we
-     * should create more.
-     *
-     * @var int
-     */
-    protected $highWorkersThreshold;
-
-    /**
      * How long the ProbeDispatcher can run for, in seconds. You can specify 0 to
      * indicate an infinitely running process.
      *
      * @var int
      */
     protected $maxRuntime;
-
-    /**
-     * Indexed by process id and stored in micro time, an in-memory storage of
-     * when a given worker was started.
-     *
-     * @var float[]
-     */
-    protected $startTimes = [];
-
-    /**
-     * Indexed by process id and stored in seconds, the amount of time we expect a
-     * given worker to run for before forcefully terminating it.
-     *
-     * @var int[]
-     */
-    protected $expectedRuntime = [];
 
     /**
      * The LoopInterface that runs our process.
@@ -194,6 +85,8 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
      */
     private $instructionBuilder;
 
+    private $workerManager;
+
     /**
      * ProbeDispatcherCommand constructor.
      *
@@ -202,7 +95,7 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
      *                                       the state of our program.
      *
      * @param InstructionBuilder $instructionBuilder
-     * @param KernelInterface $kernel
+     * @param WorkerManager $workerManager
      *
      * @throws \Symfony\Component\Console\Exception\LogicException
      */
@@ -210,11 +103,11 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
         ProbeStore $probeStore,
         LoggerInterface $logger,
         InstructionBuilder $instructionBuilder,
-        KernelInterface $kernel
+        WorkerManager $workerManager
     ) {
-        $this->kernel = $kernel;
         $this->logger = $logger;
         $this->probeStore = $probeStore;
+        $this->workerManager = $workerManager;
         $this->instructionBuilder = $instructionBuilder;
         parent::__construct();
     }
@@ -235,7 +128,7 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
                 'w',
                 InputOption::VALUE_REQUIRED,
                 'Specifies the amount of workers to start out with.',
-                50
+                5
             )
             ->addOption(
                 'minimum-available-workers',
@@ -250,13 +143,6 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
                 InputOption::VALUE_REQUIRED,
                 'Specifies the maximum amount of workers that can ever be created.',
                 200
-            )
-            ->addOption(
-                'high-workers-threshold',
-                'high',
-                InputOption::VALUE_REQUIRED,
-                'Threshold for alerting when a high number of workers is reached.',
-                150
             )
             ->addOption(
                 'max-runtime',
@@ -275,16 +161,7 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
      */
     private function setUp(InputInterface $input)
     {
-        $this->initWorkers = $input->getOption('workers');
-        $this->minimumIdleWorkers = $input->getOption('minimum-available-workers');
-        $this->maximumWorkers = $input->getOption('maximum-workers');
-        $this->highWorkersThreshold = $input->getOption('high-workers-threshold');
         $this->maxRuntime = $input->getOption('max-runtime');
-
-        if ($this->highWorkersThreshold >= $this->maximumWorkers) {
-            $str = 'High workers threshold must be less than maximum workers';
-            throw new RuntimeException($str);
-        }
 
         foreach (['SLAVE_NAME', 'SLAVE_URL'] as $item) {
             if (!getenv($item)) {
@@ -292,11 +169,16 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
             }
         }
 
-        $this->workersNeeded = 0;
+        $this->workerManager->initialize(
+            intval($input->getOption('workers')),
+            intval($input->getOption('maximum-workers')),
+            intval($input->getOption('minimum-available-workers')),
+            $this->numberOfQueues
+        );
 
         for ($i = 0; $i < $this->numberOfQueues; $i++) {
             $this->queues[$i] = new Queue(
-                $this,
+                $this->workerManager,
                 $i,
                 getenv('SLAVE_NAME'),
                 $this->logger
@@ -365,61 +247,15 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
                             $instruction['guid'] = $this->generateRandomString(25);
                             $this->sendInstruction(
                                 $instruction,
-                                null,
                                 $probe->getStep()
                             );
                         }
                     }
                 }
-
-                //keep 1 worker above the minimum required
-                $this->workersNeeded = $this->minimumIdleWorkers - count($this->availableWorkers) - $this->workersNeeded + 1;
-
-                while ($this->workersNeeded > 0) {
-                    if (count($this->processes) >= $this->maximumWorkers) {
-                        $this->logger->critical("Cannot create " . $this->workersNeeded . " more workers, hard limit (maximum-workers=" . $this->maximumWorkers . ") reached.");
-                        break;
-                    }
-
-                    if (count($this->processes) >= $this->highWorkersThreshold) {
-                        $this->logger->alert("Nearing the upper worker " . $this->highWorkersThreshold . " threshold, investigate high workload or tweak settings!");
-                    }
-                    $this->logger->info("Starting extra worker (minimum-idle=".$this->minimumIdleWorkers.", available=".count($this->availableWorkers).", needed=".$this->workersNeeded.")");
-                    $this->startWorker();
-                    --$this->workersNeeded;
-                }
             }
         );
 
-        // Get worker responses
-        $this->loop->addPeriodicTimer(
-            0.1,
-            function () {
-                foreach ($this->processes as $pid => $process) {
-                    try {
-                        if (!\in_array($pid, $this->inUseWorkers, true)) {
-                            $process->checkTimeout();
-                        } elseif (isset($this->startTimes[$pid], $this->expectedRuntime[$pid])) {
-                            $actualRuntime = microtime(true) - $this->startTimes[$pid];
-                            $expectedRuntime = $this->expectedRuntime[$pid] * 1.25;
-                            if ($actualRuntime > $expectedRuntime) {
-                                $str = "Worker $pid has exceeded the expected runtime, terminating.";
-                                $this->logger->info($str);
-                                $process->checkTimeout();
-                            }
-                        }
-                        $process->getIncrementalOutput();
-                    } catch (ProcessTimedOutException $exception) {
-                        $this->logger->info("Worker $pid timed out", [
-                            'available' => count($this->availableWorkers),
-                            'inuse' => count($this->inUseWorkers),
-                            'processes' => count($this->processes)
-                        ]);
-                        $this->cleanup($pid);
-                    }
-                }
-            }
-        );
+        $this->loop->addPeriodicTimer(0.1, function () {$this->workerManager->loop();});
 
         if ($this->maxRuntime > 0) {
             $this->logger->info('Running for ' . $this->maxRuntime . ' seconds');
@@ -432,116 +268,36 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
             );
         }
 
-        $this->logger->info('Starting ' . $input->getOption('workers') . ' workers.');
-        for ($w = 0; $w < $input->getOption('workers'); $w++) {
-            $worker = $this->startWorker();
-            $workerPid = $worker->getPid();
-            $this->logger->info(
-                "Worker[$workerPid] started.",
-                [
-                    'available' => count($this->availableWorkers),
-                    'inuse' => count($this->inUseWorkers),
-                    'processes' => count($this->processes)
-                ]
-            );
-            sleep(2);
-        }
-
         $this->loop->run();
     }
 
     /**
      * @param array $instruction
-     * @param null  $pid
      * @param int   $expectedRuntime
      *
      * @throws Exception
      */
-    public function sendInstruction(
-        array $instruction,
-        $pid = null,
-        $expectedRuntime = null
-    ): void {
+    public function sendInstruction(array $instruction, $expectedRuntime = null): void
+    {
         $expectedRuntime = $expectedRuntime ?? 60;
-        if ($pid === null) {
-            try {
-                $worker = $this->getWorker();
-                $pid = $worker->getPid();
-            } catch (Exception $e) {
-                $this->logger->critical($e->getMessage());
-                return;
-            }
+        try {
+            $worker = $this->workerManager->getWorker($instruction['type']);
+        } catch (Exception $e) {
+            $this->logger->critical($e->getMessage());
+            return;
         }
 
         if (json_encode($instruction) === false) {
-            $str = "Could not send encode the instruction for worker $pid to json.";
+            $str = "Could not send encode the instruction for worker $worker to json.";
             $this->logger->critical($str);
             return;
         }
 
-        $jsonInstruction = json_encode($instruction);
+        $worker->send(json_encode($instruction), $expectedRuntime, function($type, $response){
+            $this->handleResponse($type, $response);
+        });
 
-        $input = $this->getInput($pid);
-        $input->write($jsonInstruction);
-
-        $this->logger->info('COMMUNICATION_FLOW: Master sent ' . $instruction['type'] . " instruction to worker $pid.");
-
-        $this->startTimes[$pid] = microtime(true);
-        $this->expectedRuntime[$pid] = $expectedRuntime;
-    }
-
-    /**
-     * @return mixed
-     * @throws Exception
-     */
-    public function getWorker()
-    {
-        if (count($this->availableWorkers) > 0) {
-            if (count($this->availableWorkers) < $this->minimumIdleWorkers) {
-                $this->logger->warning('We do not have the minimum amount of workers available, one will be created.');
-                ++$this->workersNeeded;
-            }
-            return $this->getWorkerInternal();
-        }
-
-        ++$this->workersNeeded;
-        throw new RuntimeException('A worker was requested but none were available.');
-    }
-
-    /**
-     *
-     * @return Process
-     */
-    private function getWorkerInternal(): Process
-    {
-        $pid = array_shift($this->availableWorkers);
-        $this->inUseWorkers[] = $pid;
-        $process = $this->processes[$pid];
-
-        $this->logger->info("Marking worker $pid as in-use.");
-
-        return $process;
-    }
-
-    /**
-     * Get or create a new InputStream for a given $id.
-     *
-     * @param int $pid
-     *
-     * @return InputStream
-     * @throws Exception
-     */
-    private function getInput(?int $pid): InputStream
-    {
-        if (!isset($this->processes[$pid])) {
-            throw new RuntimeException("Process for PID=$pid not found.");
-        }
-
-        if (!isset($this->inputStreams[$pid])) {
-            throw new RuntimeException("Input for PID=$pid not found.");
-        }
-
-        return $this->inputStreams[$pid];
+        $this->logger->info('COMMUNICATION_FLOW: Master sent ' . $instruction['type'] . " instruction to worker $worker.");
     }
 
     /**
@@ -560,58 +316,6 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
             $randomString .= $characters[random_int(0, $charactersLength - 1)];
         }
         return $randomString;
-    }
-
-    /**
-     *
-     * @return Process
-     * @throws \Symfony\Component\Process\Exception\InvalidArgumentException
-     * @throws \Symfony\Component\Process\Exception\LogicException
-     * @throws \Symfony\Component\Process\Exception\RuntimeException
-     */
-    private function startWorker(): Process
-    {
-        $this->logger->info('Starting new worker.');
-
-        $executable = $this->kernel->getRootDir() . '/../bin/console';
-        $environment = $this->kernel->getEnvironment();
-        $process = new Process(
-            "exec php $executable app:probe:worker --env=$environment"
-        );
-        $input = new InputStream();
-
-        $process->setInput($input);
-        $process->setTimeout(1500);
-        $process->setIdleTimeout(300);
-
-        $process->start(
-            function ($type, $data) use ($process) {
-                $pid = $process->getPid();
-
-                if (isset($this->receiveBuffers[$pid])) {
-                    $this->receiveBuffers[$pid] .= $data;
-                } else {
-                    $this->receiveBuffers[$pid] = '';
-                }
-
-                if (json_decode($this->receiveBuffers[$pid], true)) {
-                    $this->handleResponse($type, $this->receiveBuffers[$pid]);
-
-                    $this->releaseWorker($pid);
-                }
-            }
-        );
-
-        $pid = $process->getPid();
-        $this->logger->info("Started Process/$pid");
-
-        $this->processes[$pid] = $process;
-        $this->inputStreams[$pid] = $input;
-        $this->receiveBuffers[$pid] = '';
-
-        $this->availableWorkers[] = $pid;
-
-        return $process;
     }
 
     /**
@@ -651,10 +355,6 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
 
         $this->logger->info("COMMUNICATION_FLOW: Master received $type response from worker $pid with a runtime of $runtime.");
 
-        if (!array_key_exists($pid, $this->processes)) {
-            $this->logger->critical('Received a response from an unknown process...');
-        }
-
         switch ($type) {
             case 'exception':
                 $this->logger->alert("Response ($status) from worker $pid returned an exception: " . print_r($contents, true));
@@ -686,21 +386,6 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
                 }
                 break;
 
-            case 'post-result':
-                $found = false;
-                foreach ($this->queues as $queue) {
-                    if ($queue->getWorker() === $pid) {
-                        $queue->result($status);
-                        $this->receiveBuffers[$queue->getWorker()] = '';
-                        $found = true;
-                    }
-                }
-                if (!$found) {
-                    $this->logger->warning("Could not find the queue for worker $pid");
-                }
-
-                break;
-
             case 'config-sync':
                 if ($status === 200) {
                     $etag = $response['headers']['etag'];
@@ -716,66 +401,6 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
                     "Response ($status) from worker $pid type $type is not supported by the response handler."
                 );
         }
-    }
-
-    /**
-     * @param int $pid
-     */
-    private function releaseWorker(int $pid): void
-    {
-        $this->receiveBuffers[$pid] = '';
-
-        foreach ($this->inUseWorkers as $index => $inUsePid) {
-            if ($pid === $inUsePid) {
-                unset($this->inUseWorkers[$index]);
-            }
-        }
-
-        foreach ($this->availableWorkers as $index => $availablePid) {
-            if ($pid === $availablePid) {
-                $this->logger->warning("Worker $pid was apparently available when asked to be released, investigate!");
-                unset($this->availableWorkers[$index]);
-            }
-        }
-
-        unset($this->startTimes[$pid], $this->expectedRuntime[$pid]);
-
-        $this->logger->info("Marking worker $pid as available.");
-        $this->availableWorkers[] = $pid;
-    }
-
-    /**
-     * Clean up tracking, inputs, processes and receive buffers.
-     *
-     * @param int $pid
-     */
-    private function cleanup(int $pid): void
-    {
-        if (array_key_exists($pid, $this->trackingIds)) {
-            $this->logger->info("Process [$pid] cleanup started but no data received yet...");
-        }
-
-        if (isset($this->processes[$pid])) {
-            $this->processes[$pid]->stop(3, SIGINT);
-            unset($this->processes[$pid]);
-        }
-
-        if (($key = array_search($pid, $this->availableWorkers, true)) !== false) {
-            /** @var int $key */
-            unset($this->availableWorkers[$key]);
-        }
-
-        if (($key = array_search($pid, $this->inUseWorkers, true)) !== false) {
-            /** @var int $key */
-            unset($this->inUseWorkers[$key]);
-        }
-
-        unset(
-            $this->inputStreams[$pid],
-            $this->receiveBuffers[$pid],
-            $this->startTimes[$pid],
-            $this->expectedRuntime[$pid]
-        );
     }
 
     /**

--- a/src/Command/ProbeDispatcherCommand.php
+++ b/src/Command/ProbeDispatcherCommand.php
@@ -394,7 +394,7 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
 
                     $count = 0;
                     foreach ($this->probeStore->getProbes() as $probe) {
-                        $count += ceil($this->probeStore->getProbeDeviceCount($probe->getId()) % $this->devicesPerWorker);
+                        $count += ceil($this->probeStore->getProbeDeviceCount($probe->getId()) / $this->devicesPerWorker);
                     }
                     $this->workerManager->setNumberOfProbeProcesses(intval($count));
                 } else {

--- a/src/Command/ProbeDispatcherCommand.php
+++ b/src/Command/ProbeDispatcherCommand.php
@@ -133,13 +133,6 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
                 5
             )
             ->addOption(
-                'minimum-available-workers',
-                'min',
-                InputOption::VALUE_REQUIRED,
-                'Specifies the minimum amount of available workers at all times.',
-                5
-            )
-            ->addOption(
                 'maximum-workers',
                 'max',
                 InputOption::VALUE_REQUIRED,
@@ -174,7 +167,6 @@ class ProbeDispatcherCommand extends ContainerAwareCommand
         $this->workerManager->initialize(
             intval($input->getOption('workers')),
             intval($input->getOption('maximum-workers')),
-            intval($input->getOption('minimum-available-workers')),
             $this->numberOfQueues
         );
 

--- a/src/DependencyInjection/Queue.php
+++ b/src/DependencyInjection/Queue.php
@@ -2,7 +2,6 @@
 
 namespace App\DependencyInjection;
 
-use App\Command\ProbeDispatcherCommand;
 use Psr\Log\LoggerInterface;
 
 class Queue
@@ -14,15 +13,15 @@ class Queue
     private $worker;
     private $logger;
     private $id;
-    private $dispatcher;
+    private $workerManager;
     private $targetsPerPacket = 50;
 
-    public function __construct(ProbeDispatcherCommand $dispatcher, int $id, string $slaveName, LoggerInterface $logger)
+    public function __construct(WorkerManager $workerManager, int $id, string $slaveName, LoggerInterface $logger)
     {
         $this->id = $id;
         $this->logger = $logger;
         $this->slaveName = $slaveName;
-        $this->dispatcher = $dispatcher;
+        $this->workerManager = $workerManager;
         $this->queue = new \SplQueue();
     }
 
@@ -37,7 +36,7 @@ class Queue
             if (!$this->queue->isEmpty()) {
                 try {
                     if (!$this->worker) {
-                        $this->reservePoster();
+                        $this->reserveWorker();
                     }
                     $this->lock = true;
                     $this->current = $this->getNextPacket();
@@ -52,13 +51,47 @@ class Queue
                         'body' => $this->current,
                     );
 
-                    $this->dispatcher->sendInstruction($instruction, $this->worker);
+                    $this->worker->send(json_encode($instruction), 60, function($type, $response){
+                        $this->handleResponse($type, $response);
+                    });
+
+                    $this->logger->info('COMMUNICATION_FLOW: Queue '.$this->id.' sent ' . $instruction['type'] . " instruction to worker $this->worker.");
+
                 } catch (\Exception $e) {
                     $this->lock = false;
                     $this->logger->warning($e->getMessage()." at ".$e->getFile().":".$e->getLine());
                 }
             }
         }
+    }
+
+    private function handleResponse($type, $data)
+    {
+        $this->logger->info("[$type] data received");
+
+        $response = json_decode($data, true);
+
+        if (!$response) {
+            $this->logger->warning('COMMUNICATION_FLOW: Response from worker could not be decoded to JSON.');
+            return;
+        }
+
+        $status = $response['status'];
+
+        if ($status === 200) {
+            $this->logger->info("Response ($status) from worker $this->worker saved.");
+            $this->current = null;
+        } elseif ($status === 409) {
+            $this->logger->info("Response ($status) from worker $this->worker discarded.");
+            $this->current = null;
+        } else {
+            $this->logger->info("Response ($status) from worker $this->worker problem - retrying later.");
+            $this->retryPost();
+        }
+
+        $this->lock = false;
+        $this->worker = null;
+        $this->logger->info("Queue $this->id items remain: " . $this->queue->count() . ".");
     }
 
     private function getNextPacket()
@@ -87,31 +120,11 @@ class Queue
         return $first;
     }
 
-    public function result($status)
-    {
-        if ($status === 200) {
-            $this->logger->info("Response ($status) from worker $this->worker saved.");
-            $this->current = null;
-        } elseif ($status === 409) {
-            $this->logger->info("Response ($status) from worker .$this->worker discarded.");
-            $this->current = null;
-        } else {
-            $this->logger->info("Response ($status) from worker $this->worker problem - retrying later.");
-            $this->retryPost();
-        }
-
-        $this->worker = null;
-        $this->lock = false;
-        $this->logger->info("Queue $this->id items remain: " . $this->queue->count() . ".");
-    }
-
-    private function reservePoster()
+    private function reserveWorker()
     {
         try {
-            $worker       = $this->dispatcher->getWorker();
-            $workerPid    = $worker->getPid();
-            $this->worker = $workerPid;
-            $this->logger->info("Worker $workerPid reserved to post data for queue ".$this->id);
+            $this->worker = $this->workerManager->getWorker('queue');
+            $this->logger->info("Worker $this->worker reserved to post data for queue ".$this->id);
         } catch (\Exception $e) {
             $this->logger->critical("Could not reserve a worker to post data for queue ".$this->id);
         }
@@ -124,10 +137,5 @@ class Queue
             $this->queue->unshift($this->current);
             $this->current = null;
         }
-    }
-
-    public function getWorker()
-    {
-        return $this->worker;
     }
 }

--- a/src/DependencyInjection/Queue.php
+++ b/src/DependencyInjection/Queue.php
@@ -38,6 +38,10 @@ class Queue
                     if (!$this->worker) {
                         $this->reserveWorker();
                     }
+                    if (!$this->worker) {
+                        $this->logger->warning("Queue $this->id had no worker");
+                        return;
+                    }
                     $this->lock = true;
                     $this->current = $this->getNextPacket();
 
@@ -67,8 +71,6 @@ class Queue
 
     private function handleResponse($type, $data)
     {
-        $this->logger->info("[$type] data received");
-
         $response = json_decode($data, true);
 
         if (!$response) {

--- a/src/DependencyInjection/Worker.php
+++ b/src/DependencyInjection/Worker.php
@@ -33,6 +33,8 @@ class Worker
 
     private $type;
 
+    private $name;
+
     public function __construct(WorkerManager $manager, KernelInterface $kernel, LoggerInterface $logger, int $timeout, int $idleTimeout)
     {
         $this->manager = $manager;
@@ -56,13 +58,14 @@ class Worker
                 $this->receiveBuffer .= $data;
 
                 if (json_decode($this->receiveBuffer, true)) {
-                    $this->logger->info("$this received a valid json, calling callback");
                     ($this->callback)($type, $this->receiveBuffer);
 
                     $this->release();
                 }
             }
         );
+
+        $this->name = "#".$this->process->getPid();
     }
 
     public function stop()
@@ -106,7 +109,7 @@ class Worker
 
     public function __toString()
     {
-        return "#".$this->process->getPid();
+        return $this->name;
     }
 
     public function getType()

--- a/src/DependencyInjection/Worker.php
+++ b/src/DependencyInjection/Worker.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jimmyc
+ * Date: 4/09/2018
+ * Time: 11:18
+ */
+
+namespace App\DependencyInjection;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Process\InputStream;
+use Symfony\Component\Process\Process;
+
+class Worker
+{
+    private $manager;
+
+    private $input;
+
+    private $process;
+
+    private $receiveBuffer = '';
+
+    private $startTime;
+
+    private $expectedRuntime;
+
+    private $callback;
+
+    private $logger;
+
+    private $type;
+
+    public function __construct(WorkerManager $manager, KernelInterface $kernel, LoggerInterface $logger, int $timeout, int $idleTimeout)
+    {
+        $this->manager = $manager;
+        $this->logger = $logger;
+        $executable = $kernel->getRootDir() . '/../bin/console';
+        $environment = $kernel->getEnvironment();
+        $this->process = new Process("exec php $executable app:probe:worker --env=$environment");
+        $this->input = new InputStream();
+
+        $this->process->setInput($this->input);
+        $this->process->setTimeout($timeout);
+        $this->process->setIdleTimeout($idleTimeout);
+    }
+
+    public function start()
+    {
+        $this->logger->info('Starting new worker.');
+
+        $this->process->start(
+            function ($type, $data) {
+                $this->receiveBuffer .= $data;
+
+                if (json_decode($this->receiveBuffer, true)) {
+                    $this->logger->info("$this received a valid json, calling callback");
+                    ($this->callback)($type, $this->receiveBuffer);
+
+                    $this->release();
+                }
+            }
+        );
+    }
+
+    public function stop()
+    {
+        $this->process->stop(3, SIGINT);
+        $this->receiveBuffer = null;
+        $this->input = null;
+        $this->startTime = null;
+        $this->expectedRuntime = null;
+    }
+
+    public function release()
+    {
+        $this->receiveBuffer = '';
+        $this->startTime = null;
+        $this->expectedRuntime = null;
+        $this->manager->release($this);
+    }
+
+    public function send($data, $expectedRuntime, \Closure $callback)
+    {
+        $this->startTime = microtime(true);
+        $this->expectedRuntime = $expectedRuntime;
+        $this->callback = $callback;
+
+        $this->input->write($data);
+    }
+
+    public function loop()
+    {
+        if ($this->startTime != null && $this->expectedRuntime != null) {
+            $actualRuntime = microtime(true) - $this->startTime;
+            $expectedRuntime = $this->expectedRuntime * 1.25;
+            if ($actualRuntime > $expectedRuntime) {
+                $this->logger->info("Worker $this has exceeded the expected runtime, terminating.");
+            }
+        }
+        $this->process->checkTimeout();
+        $this->process->getIncrementalOutput();
+    }
+
+    public function __toString()
+    {
+        return "#".$this->process->getPid();
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/DependencyInjection/WorkerManager.php
+++ b/src/DependencyInjection/WorkerManager.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jimmyc
+ * Date: 4/09/2018
+ * Time: 10:27
+ */
+
+namespace App\DependencyInjection;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class WorkerManager
+{
+    /**
+     * Holds the Application Kernel
+     *
+     * @var KernelInterface
+     */
+    protected $kernel;
+
+    /**
+     * An array of process ids of workers that are currently idle.
+     *
+     * @var int[]
+     */
+    protected $availableWorkers = [];
+
+    private $workers = [];
+    /**
+     * An array of process ids of workers that are currently performing a task.
+     *
+     * @var int[]
+     */
+    protected $inUseWorkers = [];
+
+    protected $inUseWorkerTypes = [];
+
+    /**
+     * The amount of workers that need to be created during the next cycle
+     *
+     * @var int
+     */
+    protected $workersNeeded;
+
+    /**
+     * The minimum amount of workers that should be idle at all times.
+     *
+     * @var int
+     */
+    protected $minimumIdleWorkers;
+
+    /**
+     * At most this many workers should ever be created.
+     *
+     * @var int
+     */
+    protected $maximumWorkers;
+
+    private $numberOfQueues;
+
+
+    public function __construct(KernelInterface $kernel, LoggerInterface $logger)
+    {
+        $this->kernel = $kernel;
+        $this->logger = $logger;
+    }
+
+    public function initialize(int $startWorkers, int $maximumWorkers, int $minimumIdleWorkers, int $numberOfQueues)
+    {
+        $this->maximumWorkers = $maximumWorkers;
+        $this->minimumIdleWorkers = $minimumIdleWorkers;
+        $this->numberOfQueues = $numberOfQueues;
+
+        if ($this->minimumIdleWorkers < $this->getWorkerBaseline()) {
+            $this->logger->warning("Increasing initial workers to ".$this->getWorkerBaseline());
+            $startWorkers = $this->getWorkerBaseline();
+        }
+
+        $this->logger->info("Starting $startWorkers initial workers.");
+
+        for ($w = 0; $w < $startWorkers; $w++) {
+            $this->startWorker();
+            sleep(1);
+        }
+    }
+
+    private function getWorkerBaseline()
+    {
+        return $this->numberOfQueues + 1;
+    }
+
+    public function getWorker(string $type) : Worker
+    {
+        if (!isset($this->inUseWorkerTypes[$type])) {
+            $this->inUseWorkerTypes[$type] = 0;
+        }
+
+        if (count($this->availableWorkers) > 0) {
+
+            $worker = array_shift($this->availableWorkers);
+            $this->inUseWorkers[] = $worker;
+
+            $this->logger->info("Marking worker $worker as in-use.");
+
+            $worker->setType($type);
+            $this->inUseWorkerTypes[$type]++;
+
+            foreach($this->inUseWorkerTypes as $type => $value) {
+                $this->logger->info("$value workers with type $type");
+            }
+            return $worker;
+        }
+
+        throw new \RuntimeException('A worker was requested but none were available.');
+    }
+
+    /**
+     *
+     * @return Worker
+     * @throws \Symfony\Component\Process\Exception\InvalidArgumentException
+     * @throws \Symfony\Component\Process\Exception\LogicException
+     * @throws \Symfony\Component\Process\Exception\RuntimeException
+     */
+    private function startWorker(): Worker
+    {
+        $worker = new Worker($this, $this->kernel, $this->logger, 1500, 300);
+        $worker->start();
+
+        $this->availableWorkers[] = $worker;
+        $this->workers[] = $worker;
+
+        $this->logger->info(
+            "Worker $worker started.",
+            [
+                'available' => count($this->availableWorkers),
+                'inuse' => count($this->inUseWorkers),
+                'worker' => count($this->workers)
+            ]
+        );
+
+        return $worker;
+    }
+
+    /**
+     * @param Worker $worker
+     */
+    public function release(Worker $worker): void
+    {
+        foreach ($this->inUseWorkers as $index => $inUseWorker) {
+            if ($worker === $inUseWorker) {
+                unset($this->inUseWorkers[$index]);
+            }
+        }
+
+        foreach ($this->availableWorkers as $index => $availableWorker) {
+            if ($worker === $availableWorker) {
+                $this->logger->warning("Worker $worker was apparently available when asked to be released, investigate!");
+                unset($this->availableWorkers[$index]);
+            }
+        }
+
+        $this->logger->info("Marking worker $worker as available.");
+        $this->availableWorkers[] = $worker;
+        $this->inUseWorkerTypes[$worker->getType()]--;
+        $worker->setType(null);
+
+        foreach($this->inUseWorkerTypes as $type => $value) {
+            $this->logger->info("$value workers with type $type");
+        }
+    }
+
+    /**
+     * Clean up tracking, inputs, processes and receive buffers.
+     *
+     * @param Worker $worker
+     */
+    private function cleanup(Worker $worker): void
+    {
+        $worker->stop();
+
+        if (($key = array_search($worker, $this->availableWorkers, true)) !== false) {
+            unset($this->availableWorkers[$key]);
+        }
+
+        if (($key = array_search($worker, $this->inUseWorkers, true)) !== false) {
+            unset($this->inUseWorkers[$key]);
+        }
+    }
+
+    public function loop()
+    {
+        foreach ($this->workers as $worker) {
+            try {
+                $worker->loop();
+            } catch (ProcessTimedOutException $exception) {
+                $this->logger->info("Worker $worker timed out", [
+                    'available' => count($this->availableWorkers),
+                    'inuse' => count($this->inUseWorkers),
+                    'worker' => count($this->workers)
+                ]);
+                $this->cleanup($worker);
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/WorkerManager.php
+++ b/src/DependencyInjection/WorkerManager.php
@@ -59,7 +59,9 @@ class WorkerManager
      */
     protected $maximumWorkers;
 
-    private $numberOfQueues;
+    private $numberOfQueues = 0;
+
+    private $numberOfProbeProcesses = 0;
 
 
     public function __construct(KernelInterface $kernel, LoggerInterface $logger)
@@ -87,9 +89,14 @@ class WorkerManager
         }
     }
 
+    public function setNumberOfProbeProcesses(int $numberOfProbeProcesses)
+    {
+        $this->numberOfProbeProcesses = $numberOfProbeProcesses;
+    }
+
     private function getWorkerBaseline()
     {
-        return $this->numberOfQueues + 1;
+        return $this->numberOfQueues + ($this->numberOfProbeProcesses * 2) + 1;
     }
 
     public function getWorker(string $type) : Worker
@@ -210,7 +217,7 @@ class WorkerManager
         }
 
         //check if we have enough workers available and start 1 if needed
-        if (count($this->availableWorkers) < $this->minimumIdleWorkers) {
+        if (count($this->workers) < $this->getWorkerBaseline()) {
             $this->logger->info("Not enough workers available, starting 1");
             $this->startWorker();
         }

--- a/tests/App/Command/ProbeDispatcherCommandTest.php
+++ b/tests/App/Command/ProbeDispatcherCommandTest.php
@@ -5,7 +5,9 @@ namespace Tests\App\Command;
 
 use App\Command\ProbeDispatcherCommand;
 use App\DependencyInjection\ProbeStore;
+use App\DependencyInjection\WorkerManager;
 use App\Instruction\InstructionBuilder;
+use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -28,11 +30,16 @@ class ProbeDispatcherCommandTest extends KernelTestCase
         $probeStore->getEtag()->willReturn("etag");
         $probeStore         = $probeStore->reveal();
 
+        $worker = $this->prophesize(Worker::class)->reveal();
         $logger             = $this->prophesize(LoggerInterface::class)->reveal();
         $instructionBuilder = $this->prophesize(InstructionBuilder::class)->reveal();
+        $workerManager = $this->prophesize(WorkerManager::class);
+        $workerManager->initialize(Argument::type('int'), Argument::type('int'), Argument::type('int'))->shouldBeCalledTimes(1);
+        $workerManager->loop()->willReturn();
+        $workerManager->getWorker(Argument::any())->willReturn($worker);
 
         $application->add(
-            new ProbeDispatcherCommand($probeStore, $logger, $instructionBuilder, $kernel)
+            new ProbeDispatcherCommand($probeStore, $logger, $instructionBuilder, $workerManager->reveal())
         );
 
         $command       = $application->find('app:probe:dispatcher');

--- a/tests/App/DependencyInjection/QueueTest.php
+++ b/tests/App/DependencyInjection/QueueTest.php
@@ -3,23 +3,25 @@
 namespace Tests\App\DependencyInjection;
 
 use App\DependencyInjection\Queue;
+use App\DependencyInjection\Worker;
+use App\DependencyInjection\WorkerManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
-class PingGraphTest extends TestCase
+class QueueTest extends TestCase
 {
     public function testQueueSameTimestamp()
     {
         $logger = $this->prophesize('Psr\\Log\\LoggerInterface');
 
-        $worker = $this->prophesize("Symfony\\Component\\Process\\Process");
-        $worker->getPid()->willReturn(1234)->shouldBeCalledTimes(1);
+        $worker = $this->prophesize(Worker::class);
+        //$worker->getPid()->willReturn(1234)->shouldBeCalledTimes(1);
 
-        $dispatcher = $this->prophesize('App\\Command\\ProbeDispatcherCommand');
-        $dispatcher->getWorker()->willReturn($worker->reveal())->shouldBeCalledTimes(1);
-        $dispatcher->sendInstruction(Argument::any(), 1234)->shouldBeCalledTimes(1);
+        $workerManager = $this->prophesize(WorkerManager::class);
+        $workerManager->getWorker(Argument::any())->willReturn($worker->reveal())->shouldBeCalledTimes(1);
+        //$workerManager->sendInstruction(Argument::any(), 1234)->shouldBeCalledTimes(1);
 
-        $queue = new Queue($dispatcher->reveal(), 1, 'test', $logger->reveal());
+        $queue = new Queue($workerManager->reveal(), 1, 'test', $logger->reveal());
 
         $queue->enqueue($this->getData(1, 1000, 10));
         $queue->enqueue($this->getData(1, 1000, 11));
@@ -37,7 +39,7 @@ class PingGraphTest extends TestCase
         $queue->enqueue($this->getData(1, 1000, 23));
 
         $queue->loop();
-        $queue->result(200);
+        $queue->loop();
         $queue->loop();
         $queue->loop();
     }
@@ -46,14 +48,14 @@ class PingGraphTest extends TestCase
     {
         $logger = $this->prophesize('Psr\\Log\\LoggerInterface');
 
-        $worker = $this->prophesize("Symfony\\Component\\Process\\Process");
-        $worker->getPid()->willReturn(1234)->shouldBeCalledTimes(3);
+        $worker = $this->prophesize(Worker::class);
+        //$worker->getPid()->willReturn(1234)->shouldBeCalledTimes(3);
 
-        $dispatcher = $this->prophesize('App\\Command\\ProbeDispatcherCommand');
-        $dispatcher->getWorker()->willReturn($worker->reveal())->shouldBeCalledTimes(3);
-        $dispatcher->sendInstruction(Argument::any(), 1234)->shouldBeCalledTimes(3);
+        $workerManager = $this->prophesize(WorkerManager::class);
+        $workerManager->getWorker(Argument::any())->willReturn($worker->reveal())->shouldBeCalledTimes(1);
+        //$dispatcher->sendInstruction(Argument::any(), 1234)->shouldBeCalledTimes(3);
 
-        $queue = new Queue($dispatcher->reveal(), 1, 'test', $logger->reveal());
+        $queue = new Queue($workerManager->reveal(), 1, 'test', $logger->reveal());
 
         $queue->enqueue($this->getData(1, 1000, 10));
         $queue->enqueue($this->getData(1, 1000, 11));
@@ -71,11 +73,9 @@ class PingGraphTest extends TestCase
         $queue->enqueue($this->getData(1, 3000, 23));
 
         $queue->loop();
-        $queue->result(200);
         $queue->loop();
-        $queue->result(200);
         $queue->loop();
-        $queue->result(200);
+        $queue->loop();
         $queue->loop();
         $queue->loop();
     }


### PR DESCRIPTION
Instead of keeping a minimum amount of idle workers, this implementation will create the exact peak amount of workers needed based on the configuration that the slave receives.
This way, workers will only be started when other workers time out, or when the slave receives more devices to probe.
This will also reduce the amount of workers when the slave received less devices to probe.