### PR TITLE
Modify the logrotate configuration

### DIFF
--- a/config/logrotate/fireping-slave
+++ b/config/logrotate/fireping-slave
@@ -1,8 +1,9 @@
-/opt/fireping/var/logs/*.log {
+/opt/fireping/var/log/*.log {
     daily
     missingok
     rotate 7
     compress
     delaycompress
     notifempty
+    copytruncate
 }


### PR DESCRIPTION
Logs are stored in /opt/fireping/var/log/, not /opt/fireping/var/logs/.

Add copytruncate to stop Symfony from keeping files open.

Signed-off-by: Kevin R <22906111+cgkkevinr@users.noreply.github.com>