### PR TITLE
fix ping interval

### DIFF
--- a/src/DependencyInjection/SlaveConfiguration.php
+++ b/src/DependencyInjection/SlaveConfiguration.php
@@ -98,15 +98,6 @@ class SlaveConfiguration
                 $device = new DeviceDefinition($hostname, $ip);
                 $probe->addDevice($device);
             }
-
-            // TODO: clean up, handle via master.
-            if ($type === 'ping') {
-                $probe->setArg('retries', 0);
-                $t_wait = intval($step / $samples) * 1000;
-                $n_devs = intval(count($probe->getDevices()));
-                $interval = $t_wait / $n_devs;
-                $probe->setArg('interval', $interval);
-            }
         }
         $this->purgeAllInactiveDevices();
         $this->setEtag($etag);

--- a/src/Probe/Ping.php
+++ b/src/Probe/Ping.php
@@ -34,6 +34,9 @@ class Ping implements CommandInterface
 
     public function setArgs(array $args): void
     {
+        $args['interval'] = $args['wait_time'] / count($args['targets']);
+        $args['retries'] = 0;
+
         $this->arguments = $this->mapArguments($args['args']);
         $this->targets = $args['targets'];
     }


### PR DESCRIPTION
At this moment, the interval is calculated by dividing the wait time by the number of devices.
This is however the number of devices for the entire probe, not only this process. This results in an interval < 1ms which fping cannot handle.
I moved the calculation to the ing probe itself since it's onlt relevant there, and we know the correct number of devices there.