### PR TITLE
Get composer via a multi-stage build and avoid layers.

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,13 +1,22 @@
 FROM php:7.2-fpm
 
-RUN apt-get update && apt-get install -y fping zip git rrdtool librrd-dev zlib1g-dev mysql-client
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-RUN docker-php-ext-install pdo_mysql zip
-RUN pecl install xdebug rrd
-RUN docker-php-ext-enable xdebug rrd
-
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('SHA384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-RUN php composer-setup.php
-RUN php -r "unlink('composer-setup.php');"
-RUN mv composer.phar /usr/local/bin/composer
+RUN apt-get update \
+ && apt-get install -y \
+      fping \
+      zip \
+      git \
+      rrdtool \
+      librrd-dev \
+      zlib1g-dev \
+      mysql-client \
+ && docker-php-ext-install \
+      pdo_mysql \
+      zip \
+ && pecl install \
+      xdebug \
+      rrd \
+ && docker-php-ext-enable \
+      xdebug \
+      rrd

--- a/docker/slave/Dockerfile
+++ b/docker/slave/Dockerfile
@@ -1,16 +1,16 @@
 FROM php:7.2.3-cli-stretch
 
-RUN apt-get update
-RUN apt-get install -y fping zip git rrdtool librrd-dev
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-RUN docker-php-ext-install pcntl
-RUN pecl install rrd
-RUN docker-php-ext-enable rrd
-
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('SHA384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-RUN php composer-setup.php
-RUN php -r "unlink('composer-setup.php');"
-RUN mv composer.phar /usr/local/bin/composer
+RUN apt-get update \
+ && apt-get install -y \
+      fping \
+      zip \
+      git \
+      rrdtool \
+      librrd-dev \
+ && docker-php-ext-install pcntl \
+ && pecl install rrd \
+ && docker-php-ext-enable rrd
 
 CMD ["php", "/app/bin/console", "app:probe:dispatcher", "--env=slave"]


### PR DESCRIPTION
I noticed when building fireping from scratch, it fails on the integrity check of composer because it's an older version. I'm avoiding this here by just grabbing composer from their own builds as recommended per their documentation.

I also avoid building new intermediary layers for every step (which is what every RUN instruction does).