### PR TITLE
Clean up alert destinations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "mi-schi/phpmd-extension": "^4.2",
         "phpmd/phpmd": "^2.6",
-        "phpstan/phpstan": "^0.10",
+        "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^7.1",
         "sensiolabs/security-checker": "^5.0",
         "squizlabs/php_codesniffer": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b98bb897cb6484e133b582d8d977e9e",
+    "content-hash": "2acbd0a63034f181ae66ea9146798646",
     "packages": [
         {
             "name": "api-platform/api-pack",
@@ -8877,76 +8877,42 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.10.9",
+            "version": "0.12.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "61840df60f50e186683ba35ece82efb66bd0ab2c"
+                "reference": "37bdd26a80235d0f9045b49f4151102b7831cbe2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/61840df60f50e186683ba35ece82efb66bd0ab2c",
-                "reference": "61840df60f50e186683ba35ece82efb66bd0ab2c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37bdd26a80235d0f9045b49f4151102b7831cbe2",
+                "reference": "37bdd26a80235d0f9045b49f4151102b7831cbe2",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.3.0",
-                "jean85/pretty-package-versions": "^1.0.3",
-                "nette/bootstrap": "^2.4 || ^3.0",
-                "nette/di": "^2.4.7 || ^3.0",
-                "nette/robot-loader": "^3.0.1",
-                "nette/utils": "^2.4.5 || ^3.0",
-                "nikic/php-parser": "4.0.2 - 4.2.5",
-                "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3",
-                "symfony/console": "~3.2 || ~4.0",
-                "symfony/finder": "~3.2 || ~4.0"
-            },
-            "conflict": {
-                "symfony/console": "3.4.16 || 4.1.5"
-            },
-            "require-dev": {
-                "brianium/paratest": "^2.0",
-                "consistence/coding-standard": "^3.5",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-                "ext-gd": "*",
-                "ext-intl": "*",
-                "ext-mysqli": "*",
-                "ext-zip": "*",
-                "jakub-onderka/php-parallel-lint": "^1.0",
-                "localheinz/composer-normalize": "~0.9.0",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan-deprecation-rules": "^0.10.2",
-                "phpstan/phpstan-php-parser": "^0.10",
-                "phpstan/phpstan-phpunit": "^0.10",
-                "phpstan/phpstan-strict-rules": "^0.10",
-                "phpunit/phpunit": "^7.0",
-                "slevomat/coding-standard": "^4.7.2",
-                "squizlabs/php_codesniffer": "^3.3.2"
+                "php": "^7.1"
             },
             "bin": [
-                "bin/phpstan"
+                "phpstan",
+                "phpstan.phar"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.10-dev"
+                    "dev-master": "0.12-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "PHPStan\\": [
-                        "src/",
-                        "build/PHPStan"
-                    ]
-                }
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2020-01-07T15:26:30+00:00"
+            "time": "2020-03-02T22:29:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -44,7 +44,7 @@ services:
         public: true
 
     App\AlertDestination\Mail:
-        arguments: ["@swiftmailer.mailer.default", "@monolog.logger", "@templating"]
+        arguments: ["@swiftmailer.mailer.default", "@monolog.logger", "@twig"]
         public: true
 
     App\Storage\RrdStorage:

--- a/src/AlertDestination/AlertDestinationFactory.php
+++ b/src/AlertDestination/AlertDestinationFactory.php
@@ -1,10 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jimmyc
- * Date: 8/03/2018
- * Time: 20:03
- */
+
+declare(strict_types=1);
 
 namespace App\AlertDestination;
 

--- a/src/AlertDestination/AlertDestinationFactory.php
+++ b/src/AlertDestination/AlertDestinationFactory.php
@@ -16,7 +16,7 @@ class AlertDestinationFactory
         $this->container = $container;
     }
 
-    public function create(AlertDestination $destination) : AlertDestinationHandler
+    public function create(AlertDestination $destination) : AlertDestinationHandlerInterface
     {
         $dest = $this->container->get("App\\AlertDestination\\".ucfirst($destination->getType()));
         if ($destination->getParameters()) {

--- a/src/AlertDestination/AlertDestinationFactory.php
+++ b/src/AlertDestination/AlertDestinationFactory.php
@@ -16,7 +16,7 @@ class AlertDestinationFactory
         $this->container = $container;
     }
 
-    public function create(AlertDestination $destination) : AlertDestinationInterface
+    public function create(AlertDestination $destination) : AlertDestinationHandler
     {
         $dest = $this->container->get("App\\AlertDestination\\".ucfirst($destination->getType()));
         if ($destination->getParameters()) {

--- a/src/AlertDestination/AlertDestinationFactory.php
+++ b/src/AlertDestination/AlertDestinationFactory.php
@@ -9,16 +9,19 @@ use Psr\Container\ContainerInterface;
 
 class AlertDestinationFactory
 {
-    protected $container = null;
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
 
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }
 
-    public function create(AlertDestination $destination) : AlertDestinationHandlerInterface
+    public function create(AlertDestination $destination): AlertDestinationHandlerInterface
     {
-        $dest = $this->container->get("App\\AlertDestination\\".ucfirst($destination->getType()));
+        $dest = $this->container->get("App\\AlertDestination\\" . ucfirst($destination->getType()));
         if ($destination->getParameters()) {
             $dest->setParameters($destination->getParameters());
         }

--- a/src/AlertDestination/AlertDestinationHandler.php
+++ b/src/AlertDestination/AlertDestinationHandler.php
@@ -6,7 +6,7 @@ namespace App\AlertDestination;
 
 use App\Entity\Alert;
 
-abstract class AlertDestinationInterface
+abstract class AlertDestinationHandler
 {
     public function setParameters(array $parameters)
     {

--- a/src/AlertDestination/AlertDestinationHandler.php
+++ b/src/AlertDestination/AlertDestinationHandler.php
@@ -8,11 +8,6 @@ use App\Entity\Alert;
 
 abstract class AlertDestinationHandler
 {
-    public function setParameters(array $parameters)
-    {
-
-    }
-
     protected function getAlertMessage(Alert $alert)
     {
         if ($alert->getActive()) {
@@ -22,6 +17,7 @@ abstract class AlertDestinationHandler
         }
     }
 
+    abstract public function setParameters(array $parameters);
     abstract public function trigger(Alert $alert);
     abstract public function clear(Alert $alert);
 }

--- a/src/AlertDestination/AlertDestinationHandler.php
+++ b/src/AlertDestination/AlertDestinationHandler.php
@@ -11,10 +11,10 @@ abstract class AlertDestinationHandler
     protected function getAlertMessage(Alert $alert)
     {
         if ($alert->getActive()) {
-            return $alert->getAlertRule()->getMessageDown().": ".$alert->getDevice()->getName()." from ".$alert->getSlaveGroup()->getName();
-        } else {
-            return $alert->getAlertRule()->getMessageUp().": ".$alert->getDevice()->getName()." from ".$alert->getSlaveGroup()->getName();
+            return $alert->getAlertRule()->getMessageDown() . ": " . $alert->getDevice()->getName() . " from " . $alert->getSlaveGroup()->getName();
         }
+
+        return $alert->getAlertRule()->getMessageUp() . ": " . $alert->getDevice()->getName() . " from " . $alert->getSlaveGroup()->getName();
     }
 
     abstract public function setParameters(array $parameters);

--- a/src/AlertDestination/AlertDestinationHandler.php
+++ b/src/AlertDestination/AlertDestinationHandler.php
@@ -22,6 +22,6 @@ abstract class AlertDestinationHandler
         }
     }
 
-    public abstract function trigger(Alert $alert);
-    public abstract function clear(Alert $alert);
+    abstract public function trigger(Alert $alert);
+    abstract public function clear(Alert $alert);
 }

--- a/src/AlertDestination/AlertDestinationHandler.php
+++ b/src/AlertDestination/AlertDestinationHandler.php
@@ -6,7 +6,7 @@ namespace App\AlertDestination;
 
 use App\Entity\Alert;
 
-abstract class AlertDestinationHandler
+abstract class AlertDestinationHandler implements AlertDestinationHandlerInterface
 {
     abstract public function setParameters(array $parameters);
 
@@ -14,7 +14,7 @@ abstract class AlertDestinationHandler
 
     abstract public function clear(Alert $alert);
 
-    protected function getAlertMessage(Alert $alert)
+    public function getAlertMessage(Alert $alert)
     {
         if ($alert->getActive()) {
             return $alert->getAlertRule()->getMessageDown() . ": " . $alert->getDevice()->getName() . " from " . $alert->getSlaveGroup()->getName();

--- a/src/AlertDestination/AlertDestinationHandler.php
+++ b/src/AlertDestination/AlertDestinationHandler.php
@@ -8,13 +8,13 @@ use App\Entity\Alert;
 
 abstract class AlertDestinationHandler implements AlertDestinationHandlerInterface
 {
-    abstract public function setParameters(array $parameters);
+    abstract public function setParameters(array $parameters): void;
 
-    abstract public function trigger(Alert $alert);
+    abstract public function trigger(Alert $alert): void;
 
-    abstract public function clear(Alert $alert);
+    abstract public function clear(Alert $alert): void;
 
-    public function getAlertMessage(Alert $alert)
+    public function getAlertMessage(Alert $alert): string
     {
         if ($alert->getActive()) {
             return $alert->getAlertRule()->getMessageDown() . ": " . $alert->getDevice()->getName() . " from " . $alert->getSlaveGroup()->getName();

--- a/src/AlertDestination/AlertDestinationHandler.php
+++ b/src/AlertDestination/AlertDestinationHandler.php
@@ -8,6 +8,12 @@ use App\Entity\Alert;
 
 abstract class AlertDestinationHandler
 {
+    abstract public function setParameters(array $parameters);
+
+    abstract public function trigger(Alert $alert);
+
+    abstract public function clear(Alert $alert);
+
     protected function getAlertMessage(Alert $alert)
     {
         if ($alert->getActive()) {
@@ -16,8 +22,4 @@ abstract class AlertDestinationHandler
 
         return $alert->getAlertRule()->getMessageUp() . ": " . $alert->getDevice()->getName() . " from " . $alert->getSlaveGroup()->getName();
     }
-
-    abstract public function setParameters(array $parameters);
-    abstract public function trigger(Alert $alert);
-    abstract public function clear(Alert $alert);
 }

--- a/src/AlertDestination/AlertDestinationHandlerInterface.php
+++ b/src/AlertDestination/AlertDestinationHandlerInterface.php
@@ -8,11 +8,11 @@ use App\Entity\Alert;
 
 interface AlertDestinationHandlerInterface
 {
-    public function setParameters(array $parameters);
+    public function setParameters(array $parameters): void;
 
-    public function trigger(Alert $alert);
+    public function trigger(Alert $alert): void;
 
-    public function clear(Alert $alert);
+    public function clear(Alert $alert): void;
 
-    public function getAlertMessage(Alert $alert);
+    public function getAlertMessage(Alert $alert): string;
 }

--- a/src/AlertDestination/AlertDestinationHandlerInterface.php
+++ b/src/AlertDestination/AlertDestinationHandlerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\AlertDestination;
+
+use App\Entity\Alert;
+
+interface AlertDestinationHandlerInterface
+{
+    public function setParameters(array $parameters);
+
+    public function trigger(Alert $alert);
+
+    public function clear(Alert $alert);
+
+    public function getAlertMessage(Alert $alert);
+}

--- a/src/AlertDestination/AlertDestinationHandlerInterface.php
+++ b/src/AlertDestination/AlertDestinationHandlerInterface.php
@@ -8,6 +8,9 @@ use App\Entity\Alert;
 
 interface AlertDestinationHandlerInterface
 {
+    /**
+     * @param array<string, string|int|null> $parameters
+     */
     public function setParameters(array $parameters): void;
 
     public function trigger(Alert $alert): void;

--- a/src/AlertDestination/AlertDestinationInterface.php
+++ b/src/AlertDestination/AlertDestinationInterface.php
@@ -1,10 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jimmyc
- * Date: 8/03/2018
- * Time: 19:52
- */
+
+declare(strict_types=1);
 
 namespace App\AlertDestination;
 

--- a/src/AlertDestination/Http.php
+++ b/src/AlertDestination/Http.php
@@ -11,8 +11,17 @@ use Psr\Log\LoggerInterface;
 
 class Http extends AlertDestinationHandler
 {
+    /**
+     * @var Client
+     */
     protected $client;
+    /**
+     * @var string
+     */
     protected $url;
+    /**
+     * @var LoggerInterface
+     */
     protected $logger;
 
     public function __construct(Client $client, LoggerInterface $logger)
@@ -24,7 +33,7 @@ class Http extends AlertDestinationHandler
     public function setParameters(array $parameters): void
     {
         if ($parameters) {
-            $this->url = $parameters['url'];
+            $this->url = (string) $parameters['url'];
         }
     }
 
@@ -40,19 +49,10 @@ class Http extends AlertDestinationHandler
         }
     }
 
-    public function clear(Alert $alert): void
-    {
-        if (!$this->url) {
-            return;
-        }
-        try {
-            $this->client->post($this->url, array(RequestOptions::JSON => $this->getData($alert, 'cleared')));
-        } catch (\Exception $e) {
-            $this->logger->error($e->getMessage());
-        }
-    }
-
-    protected function getData(Alert $alert, $state)
+    /**
+     * @return array<string, string|array<string, int|string>>
+     */
+    protected function getData(Alert $alert, string $state): array
     {
         return array(
             'device' => array(
@@ -69,5 +69,17 @@ class Http extends AlertDestinationHandler
             ),
             'state' => $state
         );
+    }
+
+    public function clear(Alert $alert): void
+    {
+        if (!$this->url) {
+            return;
+        }
+        try {
+            $this->client->post($this->url, array(RequestOptions::JSON => $this->getData($alert, 'cleared')));
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+        }
     }
 }

--- a/src/AlertDestination/Http.php
+++ b/src/AlertDestination/Http.php
@@ -1,10 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jimmyc
- * Date: 8/03/2018
- * Time: 20:01
- */
+
+declare(strict_types=1);
 
 namespace App\AlertDestination;
 

--- a/src/AlertDestination/Http.php
+++ b/src/AlertDestination/Http.php
@@ -21,14 +21,14 @@ class Http extends AlertDestinationHandler
         $this->logger = $logger;
     }
 
-    public function setParameters(array $parameters)
+    public function setParameters(array $parameters): void
     {
         if ($parameters) {
             $this->url = $parameters['url'];
         }
     }
 
-    public function trigger(Alert $alert)
+    public function trigger(Alert $alert): void
     {
         if (!$this->url) {
             return;
@@ -40,7 +40,7 @@ class Http extends AlertDestinationHandler
         }
     }
 
-    public function clear(Alert $alert)
+    public function clear(Alert $alert): void
     {
         if (!$this->url) {
             return;

--- a/src/AlertDestination/Http.php
+++ b/src/AlertDestination/Http.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 use Psr\Log\LoggerInterface;
 
-class Http extends AlertDestinationInterface
+class Http extends AlertDestinationHandler
 {
     protected $client;
     protected $url;

--- a/src/AlertDestination/Mail.php
+++ b/src/AlertDestination/Mail.php
@@ -8,15 +8,23 @@ use App\Entity\Alert;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
 
-/**
- * Class Mail
- * @package App\AlertDestination
- */
 class Mail extends AlertDestinationHandler
 {
+    /**
+     * @var string
+     */
     protected $recipient;
+    /**
+     * @var \Swift_Mailer
+     */
     protected $mailer;
+    /**
+     * @var Environment
+     */
     protected $templating;
+    /**
+     * @var LoggerInterface
+     */
     protected $logger;
 
     public function __construct(\Swift_Mailer $mailer, LoggerInterface $logger, Environment $templating)
@@ -26,19 +34,13 @@ class Mail extends AlertDestinationHandler
         $this->templating = $templating;
     }
 
-    /**
-     * @param array $parameters
-     */
     public function setParameters(array $parameters): void
     {
         if ($parameters) {
-            $this->recipient = $parameters['recipient'];
+            $this->recipient = (string) $parameters['recipient'];
         }
     }
 
-    /**
-     * @param Alert $alert
-     */
     public function trigger(Alert $alert): void
     {
         if (!isset($_ENV['MAILER_FROM'])) {
@@ -49,26 +51,7 @@ class Mail extends AlertDestinationHandler
         $this->sendMail($this->recipient, $this->getAlertMessage($alert), $alert, 'ALERT');
     }
 
-    /**
-     * @param Alert $alert
-     */
-    public function clear(Alert $alert): void
-    {
-        if (!isset($_ENV['MAILER_FROM'])) {
-            $this->logger->error('MAILER_FROM env variable is not set');
-            return;
-        }
-
-        $this->sendMail($this->recipient, $this->getAlertMessage($alert), $alert, "CLEAR");
-    }
-
-    /**
-     * @param string $to
-     * @param string $subject
-     * @param Alert $alert
-     * @param string $action
-     */
-    private function sendMail(string $to, string $subject, Alert $alert, string $action)
+    private function sendMail(string $to, string $subject, Alert $alert, string $action): void
     {
         try {
             $message = (new \Swift_Message($subject))
@@ -91,5 +74,15 @@ class Mail extends AlertDestinationHandler
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
         }
+    }
+
+    public function clear(Alert $alert): void
+    {
+        if (!isset($_ENV['MAILER_FROM'])) {
+            $this->logger->error('MAILER_FROM env variable is not set');
+            return;
+        }
+
+        $this->sendMail($this->recipient, $this->getAlertMessage($alert), $alert, "CLEAR");
     }
 }

--- a/src/AlertDestination/Mail.php
+++ b/src/AlertDestination/Mail.php
@@ -1,10 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jimmyc
- * Date: 8/03/2018
- * Time: 19:46
- */
+
+declare(strict_types=1);
 
 namespace App\AlertDestination;
 

--- a/src/AlertDestination/Mail.php
+++ b/src/AlertDestination/Mail.php
@@ -6,7 +6,7 @@ namespace App\AlertDestination;
 
 use App\Entity\Alert;
 use Psr\Log\LoggerInterface;
-use Symfony\Bundle\TwigBundle\TwigEngine;
+use Twig\Environment;
 
 /**
  * Class Mail
@@ -19,13 +19,7 @@ class Mail extends AlertDestinationHandler
     protected $templating;
     protected $logger;
 
-    /**
-     * Mail constructor.
-     * @param \Swift_Mailer $mailer
-     * @param LoggerInterface $logger
-     * @param TwigEngine $templating
-     */
-    public function __construct(\Swift_Mailer $mailer, LoggerInterface $logger, TwigEngine $templating)
+    public function __construct(\Swift_Mailer $mailer, LoggerInterface $logger, Environment $templating)
     {
         $this->mailer = $mailer;
         $this->logger = $logger;

--- a/src/AlertDestination/Mail.php
+++ b/src/AlertDestination/Mail.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\TwigBundle\TwigEngine;
  * Class Mail
  * @package App\AlertDestination
  */
-class Mail extends AlertDestinationInterface
+class Mail extends AlertDestinationHandler
 {
     protected $recipient;
     protected $mailer;

--- a/src/AlertDestination/Mail.php
+++ b/src/AlertDestination/Mail.php
@@ -35,7 +35,7 @@ class Mail extends AlertDestinationHandler
     /**
      * @param array $parameters
      */
-    public function setParameters(array $parameters)
+    public function setParameters(array $parameters): void
     {
         if ($parameters) {
             $this->recipient = $parameters['recipient'];
@@ -45,7 +45,7 @@ class Mail extends AlertDestinationHandler
     /**
      * @param Alert $alert
      */
-    public function trigger(Alert $alert)
+    public function trigger(Alert $alert): void
     {
         if (!isset($_ENV['MAILER_FROM'])) {
             $this->logger->error('MAILER_FROM env variable is not set');
@@ -58,7 +58,7 @@ class Mail extends AlertDestinationHandler
     /**
      * @param Alert $alert
      */
-    public function clear(Alert $alert)
+    public function clear(Alert $alert): void
     {
         if (!isset($_ENV['MAILER_FROM'])) {
             $this->logger->error('MAILER_FROM env variable is not set');

--- a/src/AlertDestination/Monolog.php
+++ b/src/AlertDestination/Monolog.php
@@ -7,7 +7,7 @@ namespace App\AlertDestination;
 use App\Entity\Alert;
 use Psr\Log\LoggerInterface;
 
-class Monolog extends AlertDestinationInterface
+class Monolog extends AlertDestinationHandler
 {
     protected $logger;
 

--- a/src/AlertDestination/Monolog.php
+++ b/src/AlertDestination/Monolog.php
@@ -16,12 +16,12 @@ class Monolog extends AlertDestinationHandler
         $this->logger = $logger;
     }
 
-    public function trigger(Alert $alert)
+    public function trigger(Alert $alert): void
     {
         $this->logger->warning("FIREPING.ALERT: " . $this->getAlertMessage($alert));
     }
 
-    public function clear(Alert $alert)
+    public function clear(Alert $alert): void
     {
         $this->logger->warning("FIREPING.CLEAR: " . $this->getAlertMessage($alert));
     }

--- a/src/AlertDestination/Monolog.php
+++ b/src/AlertDestination/Monolog.php
@@ -1,10 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jimmyc
- * Date: 8/03/2018
- * Time: 19:46
- */
+
+declare(strict_types=1);
 
 namespace App\AlertDestination;
 

--- a/src/AlertDestination/Monolog.php
+++ b/src/AlertDestination/Monolog.php
@@ -25,4 +25,8 @@ class Monolog extends AlertDestinationHandler
     {
         $this->logger->warning("FIREPING.CLEAR: " . $this->getAlertMessage($alert));
     }
+
+    public function setParameters(array $parameters): void
+    {
+    }
 }

--- a/src/AlertDestination/Monolog.php
+++ b/src/AlertDestination/Monolog.php
@@ -9,6 +9,9 @@ use Psr\Log\LoggerInterface;
 
 class Monolog extends AlertDestinationHandler
 {
+    /**
+     * @var LoggerInterface
+     */
     protected $logger;
 
     public function __construct(LoggerInterface $logger)

--- a/src/AlertDestination/Slack.php
+++ b/src/AlertDestination/Slack.php
@@ -35,8 +35,9 @@ class Slack extends AlertDestinationHandler
     public function trigger(Alert $alert): void
     {
         if (!$this->url) {
-            return false;
+            return;
         }
+
         try {
             $data = array(
                 'username' => "fireping",
@@ -60,8 +61,9 @@ class Slack extends AlertDestinationHandler
     public function clear(Alert $alert): void
     {
         if (!$this->url) {
-            return false;
+            return;
         }
+
         try {
             $data = array(
                 'username' => "fireping",

--- a/src/AlertDestination/Slack.php
+++ b/src/AlertDestination/Slack.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\AlertDestination;
 
 use App\Entity\Alert;

--- a/src/AlertDestination/Slack.php
+++ b/src/AlertDestination/Slack.php
@@ -11,9 +11,21 @@ use Psr\Log\LoggerInterface;
 
 class Slack extends AlertDestinationHandler
 {
+    /**
+     * @var Client
+     */
     protected $client;
+    /**
+     * @var string
+     */
     protected $channel;
+    /**
+     * @var string
+     */
     protected $url;
+    /**
+     * @var LoggerInterface
+     */
     protected $logger;
 
     public function __construct(Client $client, LoggerInterface $logger)
@@ -25,10 +37,10 @@ class Slack extends AlertDestinationHandler
     public function setParameters(array $parameters): void
     {
         if ($parameters && isset($parameters['channel'])) {
-            $this->channel = $parameters['channel'];
+            $this->channel = (string) $parameters['channel'];
         }
         if ($parameters && isset($parameters['url'])) {
-            $this->url = $parameters['url'];
+            $this->url = (string) $parameters['url'];
         }
     }
 

--- a/src/AlertDestination/Slack.php
+++ b/src/AlertDestination/Slack.php
@@ -22,7 +22,7 @@ class Slack extends AlertDestinationHandler
         $this->logger = $logger;
     }
 
-    public function setParameters(array $parameters)
+    public function setParameters(array $parameters): void
     {
         if ($parameters && isset($parameters['channel'])) {
             $this->channel = $parameters['channel'];
@@ -32,7 +32,7 @@ class Slack extends AlertDestinationHandler
         }
     }
 
-    public function trigger(Alert $alert)
+    public function trigger(Alert $alert): void
     {
         if (!$this->url) {
             return false;
@@ -57,7 +57,7 @@ class Slack extends AlertDestinationHandler
         }
     }
 
-    public function clear(Alert $alert)
+    public function clear(Alert $alert): void
     {
         if (!$this->url) {
             return false;

--- a/src/AlertDestination/Slack.php
+++ b/src/AlertDestination/Slack.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 use Psr\Log\LoggerInterface;
 
-class Slack extends AlertDestinationInterface
+class Slack extends AlertDestinationHandler
 {
     protected $client;
     protected $channel;

--- a/tests/App/AlertDestination/AlertDestinationFactoryTest.php
+++ b/tests/App/AlertDestination/AlertDestinationFactoryTest.php
@@ -1,42 +1,48 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jimmyc
- * Date: 8/03/2018
- * Time: 21:11
- */
+
+declare(strict_types=1);
 
 namespace Tests\App\AlertDestination;
 
 use App\AlertDestination\AlertDestinationFactory;
+use App\AlertDestination\Http;
+use App\AlertDestination\Mail;
+use App\AlertDestination\Monolog;
+use App\AlertDestination\Slack;
 use App\Entity\AlertDestination;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class AlertDestinationFactoryTest extends WebTestCase
 {
-    public function testCreateHttp()
+    /**
+     * @var AlertDestinationFactory
+     */
+    private $factory;
+
+    /**
+     * @dataProvider typeProvider
+     */
+    public function testCreateHandler(string $type, string $class): void
     {
-        $client = static::createClient();
+        $destination = new AlertDestination();
+        $destination->setType($type);
 
-        $factory = new AlertDestinationFactory($client->getContainer());
-
-        $alertDestination = new AlertDestination();
-        $alertDestination->setType('http');
-        $http = $factory->create($alertDestination);
-
-        $this->assertEquals('App\AlertDestination\Http', get_class($http));
+        self::assertInstanceOf($class, $this->factory->create($destination));
     }
 
-    public function testCreateMonolog()
+    public function typeProvider(): array
+    {
+        return [
+            'http handler' => ['http', Http::class],
+            'mail handler' => ['mail', Mail::class],
+            'monolog handler' => ['monolog', Monolog::class],
+            'slack handler' => ['slack', Slack::class],
+        ];
+    }
+
+    protected function setUp(): void
     {
         $client = static::createClient();
-
-        $factory = new AlertDestinationFactory($client->getContainer());
-
-        $alertDestination = new AlertDestination();
-        $alertDestination->setType('monolog');
-        $monolog = $factory->create($alertDestination);
-
-        $this->assertEquals('App\AlertDestination\Monolog', get_class($monolog));
+        $this->factory = new AlertDestinationFactory($client->getContainer());
     }
 }


### PR DESCRIPTION
I did some small fixes for the AlertDestination namespace.

- [x] Changed `@templating` with `@twig` as the former is deprecated.
- [x] Extracted an interface and type hinted against that instead.
- [x] Changed `AlertDestinationInterface` to `AlertDestinationHandler` as it wasn't an interface.
- [x] Added test cases for `Monolog` and `Slack` handlers too in the `AlertDestinationFactoryTest`
- [x] Added `declare(strict_types=1)` everywhere.
- [x] Added type hints that help phpstan do its thing.
- [x] Fixed the errors that came up when running phpstan on max strictness.

The only phpstan error I didn't fix was this one:

```
 ------ --------------------------------------------------------------------------
  Line   AlertDestinationFactory.php
 ------ --------------------------------------------------------------------------
  24     Parameter #1 $str of function ucfirst expects string, string|null given.
 ------ --------------------------------------------------------------------------
```

It's caused by the fact that `AlertDestination::getType` can return `string|null` . I'm not sure how to fix this one yet. The database enforces that it's a string, but in the form it can temporarily be null until it's validated. A DTO should fix this, but I didn't want to bring that in scope of this change and I'm not sure how to combine it with EasyAdmin yet.