### PR TITLE
Throw exception when worker process does not return data in time.

### DIFF
--- a/src/Exception/WorkerTimedOutException.php
+++ b/src/Exception/WorkerTimedOutException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Exception;
+
+class WorkerTimedOutException extends \Exception
+{
+
+}


### PR DESCRIPTION
This probably means the worker has crashed and the workermanager should release and terminate that worker permanently.