### PR TITLE
Change summary graph image width to 100% of parent div

### DIFF
--- a/templates/search/index.html.twig
+++ b/templates/search/index.html.twig
@@ -13,7 +13,7 @@
                     {% block box_title %}{{ device.name }} - {{ device.ip }}{% endblock %}
                     {% block box_body_class %}p-0 text-center{% endblock %}
                     {% block box_body %}
-                        <a href="{{ path('app_device_get', {id: device.id}) }}"><img src="{{ path('app_graph_summary', {id: device.id, width:1000}) }}" /></a>
+                        <a href="{{ path('app_device_get', {id: device.id}) }}"><img src="{{ path('app_graph_summary', {id: device.id}) }}" width="100%"  alt="Summary graph for {{ device.name }}"/></a>
                     {% endblock %}
                 {% endembed %}
             {% endfor %}

--- a/templates/search/index.html.twig
+++ b/templates/search/index.html.twig
@@ -13,7 +13,7 @@
                     {% block box_title %}{{ device.name }} - {{ device.ip }}{% endblock %}
                     {% block box_body_class %}p-0 text-center{% endblock %}
                     {% block box_body %}
-                        <a href="{{ path('app_device_get', {id: device.id}) }}"><img src="{{ path('app_graph_summary', {id: device.id}) }}" width="100%"  alt="Summary graph for {{ device.name }}"/></a>
+                        <a href="{{ path('app_device_get', {id: device.id}) }}"><img style="max-width: 100%; height: auto;" src="{{ path('app_graph_summary', {id: device.id, width: 1000}) }}" alt="Summary graph for {{ device.name }}"/></a>
                     {% endblock %}
                 {% endembed %}
             {% endfor %}


### PR DESCRIPTION
This fixes a bug that pushed images out of the parent div container when the screen size was small enough. Now, it'll grab the default size summary graph and stretch it to the right size. 