### PR TITLE
Fix install faults

### DIFF
--- a/docs/docs/installation/master/database.md
+++ b/docs/docs/installation/master/database.md
@@ -20,11 +20,11 @@ $ sudo apt-get install -y mariadb-server
 Make sure it's installed and running:
 
 ```bash
-$ service mysql status
+$ sudo service mysql status
 [info] MariaDB is stopped..
-$ service mysql start
+$ sudo service mysql start
 [ ok ] Starting MariaDB database server: mysqld.
-$ service mysql status
+$ sudo service mysql status
 [info] /usr/bin/mysqladmin  Ver 9.1 Distrib 10.1.44-MariaDB, for debian-linux-gnu on x86_64
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/docs/installation/master/fireping.md
+++ b/docs/docs/installation/master/fireping.md
@@ -46,7 +46,15 @@ $ sudo git clone https://github.com/jimmycleuren/fireping.git .
 Now [install Composer](https://getcomposer.org/download/) and fetch the vendor dependencies.
 
 ```bash
-$ composer install --verbose --prefer-dist --no-dev --optimize-autoloader --no-suggest
+$ composer install --verbose --prefer-dist --no-dev --optimize-autoloader --no-scripts --no-suggest
+```
+
+Then, run some post-install scripts.
+
+```bash
+$ php bin/console cache:clear --env=prod
+$ php bin/console cache:warmup --env=prod
+$ php bin/console assets:install --symlink --relative public
 ```
 
 # Configuration

--- a/docs/docs/installation/master/fireping.md
+++ b/docs/docs/installation/master/fireping.md
@@ -57,6 +57,12 @@ $ php bin/console cache:warmup --env=prod
 $ php bin/console assets:install --symlink --relative public
 ```
 
+Make sure the log file is writable by the user running the webserver.
+
+```bash
+$ sudo chmod 777 /opt/fireping/var/log/prod.log
+```
+
 # Configuration
 
 Fireping's configuration file is called `.env.local` and is stored in the installation directory. It is not created by default.

--- a/docs/docs/installation/master/fireping.md
+++ b/docs/docs/installation/master/fireping.md
@@ -23,7 +23,7 @@ Then install the necessary system dependencies.
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get install -y php7.4 php7.4-fpm php7.4-mysql php7.4-mbstring php7.4-zip php7.4-curl php-rrd rrdtool git zip
+$ sudo apt-get install -y php7.4 php7.4-xml php7.4-fpm php7.4-mysql php7.4-mbstring php7.4-zip php7.4-curl php-rrd rrdtool git zip
 ```
 
 Make sure that php7.4-fpm is up and running.
@@ -40,7 +40,7 @@ Clone the repository to a location of your choosing.
 
 ```bash
 $ mkdir /opt/fireping && cd fireping
-$ git clone https://github.com/jimmycleuren/fireping.git .
+$ sudo git clone https://github.com/jimmycleuren/fireping.git .
 ```
 
 Now [install Composer](https://getcomposer.org/download/) and fetch the vendor dependencies.
@@ -60,7 +60,7 @@ This is a secret key used to generate CSRF tokens. You must change it. It should
 Example:
 
 ```bash
-$ php -r "echo 'APP_SECRET=' . sha1(random_bytes(50)) . PHP_EOL;" >> .env.local
+$ php -r "echo 'APP_SECRET=' . sha1(random_bytes(50)) . PHP_EOL;" | sudo tee -a .env.local
 ```
 
 ## DATABASE_URL

--- a/docs/docs/installation/master/fireping.md
+++ b/docs/docs/installation/master/fireping.md
@@ -57,7 +57,7 @@ $ php bin/console cache:warmup --env=prod
 $ php bin/console assets:install --symlink --relative public
 ```
 
-Make sure the log file is writable by the user running the webserver.
+Make sure the log file is writable by the user running the webserver. The example below lists one way to do this, however note that this will make the logs readable for any user on the system.
 
 ```bash
 $ sudo chmod 777 /opt/fireping/var/log/prod.log

--- a/docs/docs/installation/master/redis.md
+++ b/docs/docs/installation/master/redis.md
@@ -20,8 +20,8 @@ $ sudo apt-get install -y redis-server
 Make sure that redis is running.
 
 ```bash
-$ service redis-server status
-$ service redis-server start
+$ sudo service redis-server status
+$ sudo service redis-server start
 ```
 
 Verify that the installation is running and working with the `PING` command.

--- a/docs/docs/installation/master/reverse-proxy.md
+++ b/docs/docs/installation/master/reverse-proxy.md
@@ -60,11 +60,11 @@ server {
 Then, enable the configuration.
 
 ```bash
-ln -s /etc/nginx/sites-available/fireping.conf /etc/nginx/sites-enabled/fireping.conf
+sudo ln -s /etc/nginx/sites-available/fireping.conf /etc/nginx/sites-enabled/fireping.conf
 ```
 
 And reload the NGINX configuration.
 
 ```bash
-nginx -s reload
+sudo nginx -s reload
 ```

--- a/docs/docs/installation/slave/fireping.md
+++ b/docs/docs/installation/slave/fireping.md
@@ -23,14 +23,14 @@ Then install the required system dependencies.
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get install -y php7.4 php7.4-mysql php7.4-mbstring php7.4-zip php7.4-curl php-rrd rrdtool git zip supervisor fping
+$ sudo apt-get install -y php7.4 php7.4-xml php7.4-mysql php7.4-mbstring php7.4-zip php7.4-curl php-rrd rrdtool git zip supervisor fping
 ```
 
 Clone the repository to a location of your choosing.
 
 ```bash
 $ mkdir /opt/fireping-slave
-$ git clone https://github.com/jimmycleuren/fireping.git .
+$ sudo git clone https://github.com/jimmycleuren/fireping.git .
 $ cd fireping
 ```
 

--- a/docs/docs/installation/slave/fireping.md
+++ b/docs/docs/installation/slave/fireping.md
@@ -29,9 +29,8 @@ $ sudo apt-get install -y php7.4 php7.4-xml php7.4-mysql php7.4-mbstring php7.4-
 Clone the repository to a location of your choosing.
 
 ```bash
-$ mkdir /opt/fireping-slave
+$ mkdir /opt/fireping-slave && cd /opt/fireping-slave
 $ sudo git clone https://github.com/jimmycleuren/fireping.git .
-$ cd fireping
 ```
 
 Now [install Composer](https://getcomposer.org/download/) and fetch the vendor dependencies.

--- a/docs/docs/installation/slave/fireping.md
+++ b/docs/docs/installation/slave/fireping.md
@@ -38,7 +38,14 @@ Now [install Composer](https://getcomposer.org/download/) and fetch the vendor d
 
 ```bash
 $ # in /opt/fireping-slave/
-$ composer install --verbose --prefer-dist --no-dev --optimize-autoloader --no-suggest
+$ composer install --verbose --prefer-dist --no-dev --optimize-autoloader --no-scripts --no-suggest
+```
+
+Then, run some post-install scripts.
+
+```bash
+$ php bin/console cache:clear --env=prod
+$ php bin/console cache:warmup --env=prod
 ```
 
 # Configuration

--- a/docs/docs/installation/slave/fireping.md
+++ b/docs/docs/installation/slave/fireping.md
@@ -43,13 +43,21 @@ $ composer install --verbose --prefer-dist --no-dev --optimize-autoloader --no-s
 Then, run some post-install scripts.
 
 ```bash
-$ php bin/console cache:clear --env=prod
-$ php bin/console cache:warmup --env=prod
+$ php bin/console cache:clear --env=slave
+$ php bin/console cache:warmup --env=slave
 ```
 
 # Configuration
 
 Fireping's configuration file is called `.env.local` and is stored in the installation directory.
+
+## APP_ENV
+
+This changes the running application's environment.
+
+```bash
+APP_ENV=slave
+```
 
 ## SLAVE_URL
 

--- a/docs/docs/installation/slave/supervisor.md
+++ b/docs/docs/installation/slave/supervisor.md
@@ -16,11 +16,11 @@ $ apt-get install supervisor
 Make sure it's running
 
 ```bash
-$ service supervisor status
+$ sudo service supervisor status
 supervisord is  not running.
-$ service supervisor start
+$ sudo service supervisor start
 Starting supervisor: supervisord.
-$ service supervisor status
+$ sudo service supervisor status
 supervisord is running
 ```
 


### PR DESCRIPTION
This fixes a number of issues with the master's installation docs such as:

- missing sudo before various commands.
- fixing $INSTALL_DIR/var/log/prod.log file permissions.
- adding `--no-scripts` to composer install and running the cache:clear, cache:warmup and assets:install scripts manually.
- changing the APP_SECRET generation to use `sudo tee` instead of IO redirection.