### PR TITLE
Prevent modification of a Probe.

### DIFF
--- a/src/Controller/Admin/ProbeCrudController.php
+++ b/src/Controller/Admin/ProbeCrudController.php
@@ -49,7 +49,7 @@ class ProbeCrudController extends AbstractCrudController
         }
 
         if (Crud::PAGE_EDIT === $pageName) {
-            return [$name, $type, $arguments, $archives];
+            return [$name];
         }
 
         return [];

--- a/src/Controller/Admin/ProbeCrudController.php
+++ b/src/Controller/Admin/ProbeCrudController.php
@@ -38,13 +38,20 @@ class ProbeCrudController extends AbstractCrudController
 
         if (Crud::PAGE_INDEX === $pageName) {
             return [$id, $name, $type, $step, $samples, $archives];
-        } elseif (Crud::PAGE_DETAIL === $pageName) {
+        }
+
+        if (Crud::PAGE_DETAIL === $pageName) {
             return [$id, $name, $type, $step, $samples, $arguments, $archives];
-        } elseif (Crud::PAGE_NEW === $pageName) {
-            return [$name, $type, $step, $samples, $arguments, $archives];
-        } elseif (Crud::PAGE_EDIT === $pageName) {
+        }
+
+        if (Crud::PAGE_NEW === $pageName) {
             return [$name, $type, $step, $samples, $arguments, $archives];
         }
+
+        if (Crud::PAGE_EDIT === $pageName) {
+            return [$name, $type, $arguments, $archives];
+        }
+
         return [];
     }
 }


### PR DESCRIPTION
Probes aren't really designed to change right now, this formalizes that. All of these properties directly or indirectly require an rrd file change.