### PR TITLE
Ensure broken results are discarded by the ProbeDispatcher.

### DIFF
--- a/src/Controller/SlaveController.php
+++ b/src/Controller/SlaveController.php
@@ -10,6 +10,7 @@ namespace App\Controller;
 
 use App\Entity\Device;
 use App\Entity\Slave;
+use App\Exception\DirtyInputException;
 use App\Exception\WrongTimestampRrdException;
 use App\Processor\ProcessorFactory;
 use App\Repository\DeviceRepository;
@@ -282,7 +283,7 @@ class SlaveController extends AbstractController
             //execute 1 flush at the end, not for every datapoint
             $this->em->flush();
 
-        } catch (WrongTimestampRrdException $e) {
+        } catch (WrongTimestampRrdException | DirtyInputException $e) {
             $this->logger->warning($e->getMessage());
             return new JsonResponse(array('code' => 409, 'message' => $e->getMessage()), 409);
         } catch (\Exception $e) {

--- a/src/Exception/DirtyInputException.php
+++ b/src/Exception/DirtyInputException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+class DirtyInputException extends \RuntimeException
+{
+
+}

--- a/src/Processor/SmokeProcessor.php
+++ b/src/Processor/SmokeProcessor.php
@@ -11,6 +11,7 @@ namespace App\Processor;
 use App\Entity\Device;
 use App\Entity\Probe;
 use App\Entity\SlaveGroup;
+use App\Exception\DirtyInputException;
 use App\Exception\WrongTimestampRrdException;
 
 class SmokeProcessor extends Processor
@@ -20,7 +21,7 @@ class SmokeProcessor extends Processor
     public function storeResult(Device $device, Probe $probe, SlaveGroup $group, $timestamp, $data)
     {
         if (count($data) != $probe->getSamples()) {
-            throw new \Exception(count($data)." ".$this->datasource." samples received, should have been ".$probe->getSamples());
+            throw new DirtyInputException(count($data)." ".$this->datasource." samples received, should have been ".$probe->getSamples());
         }
 
         $datasources = array();

--- a/src/Processor/TracerouteProcessor.php
+++ b/src/Processor/TracerouteProcessor.php
@@ -11,6 +11,7 @@ namespace App\Processor;
 use App\Entity\Device;
 use App\Entity\Probe;
 use App\Entity\SlaveGroup;
+use App\Exception\DirtyInputException;
 use App\Exception\TracerouteException;
 
 class TracerouteProcessor extends Processor
@@ -22,10 +23,10 @@ class TracerouteProcessor extends Processor
         $prevTotal = 0;
         foreach ($data->hop as $hop => $details) {
             if (!isset($details->ip) ) {
-                throw new TracerouteException("No ip specified for hop $hop");
+                throw new DirtyInputException("No ip specified for hop $hop");
             }
             if (isset($details->latencies) && count($details->latencies) != $probe->getSamples()) {
-                throw new TracerouteException(count((array)$details)." samples received for hop $hop, should have been ".$probe->getSamples());
+                throw new DirtyInputException(count((array)$details)." samples received for hop $hop, should have been ".$probe->getSamples());
             }
             $total = 0;
             $failed = 0;

--- a/tests/App/Controller/SlaveControllerTest.php
+++ b/tests/App/Controller/SlaveControllerTest.php
@@ -141,7 +141,7 @@ class SlaveControllerTest extends AbstractApiTest
         )));
 
         $response = $this->client->getResponse();
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals(409, $response->getStatusCode());
         $this->assertTrue($response->headers->contains('Content-Type', 'application/json'));
         $this->assertJson($response->getContent());
     }
@@ -272,7 +272,7 @@ class SlaveControllerTest extends AbstractApiTest
         )));
 
         $response = $this->client->getResponse();
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals(409, $response->getStatusCode());
         $this->assertTrue($response->headers->contains('Content-Type', 'application/json'));
         $this->assertJson($response->getContent());
     }


### PR DESCRIPTION
After setting up some environments and testing around I've isolated the bug that prevented the master from persisting data to the rrd files. In all of these instances, changing the probe step value after its initial creation was the trigger. Furthermore, improper handling of *Processor related exceptions causes the dispatcher to get stuck in an infinite loop of trying to update the master with dirty data.

As such:

- Created DirtyInputException.
- Throw DirtyInputException instead of \Exception in known cases.
- Catch and return an HTTP 409 for thrown DirtyInputExceptions, replicating the discarding behaviour of WrongRrdTimestampException.

That should resolve all current issues, does it on my machine at least. 😄 