### PR TITLE
Add missing details to install docs.

### DIFF
--- a/docs/docs/installation/master/fireping.md
+++ b/docs/docs/installation/master/fireping.md
@@ -16,7 +16,11 @@ Start by adding a new package repository so that we can add the PHP7.4 binaries.
 $ sudo apt-get install -y wget gnupg ca-certificates apt-transport-https
 $ wget -q https://packages.sury.org/php/apt.gpg -O- | sudo apt-key add -
 
-$ echo "deb https://packages.sury.org/php/ stretch main" | sudo tee /etc/apt/sources.list.d/php.list
+# Automatically add for your Debian release. Make sure that https://packages.sury.org/php/dists/ has an entry for your release.
+$ env -i bash -c '. /etc/os-release; echo "deb https://packages.sury.org/php/ $VERSION_CODENAME main"' | sudo tee /etc/apt/sources.list.d/php.list
+# Alternatively, just do it manually for these known supported releases:
+# Debian 9: echo "deb https://packages.sury.org/php/ stretch main" | sudo tee /etc/apt/sources.list.d/php.list
+# Debian 10: echo "deb https://packages.sury.org/php/ buster main" | sudo tee /etc/apt/sources.list.d/php.list
 ```
 
 Then install the necessary system dependencies.

--- a/docs/docs/installation/master/fireping.md
+++ b/docs/docs/installation/master/fireping.md
@@ -43,7 +43,7 @@ $ sudo service php7.4-fpm status
 Clone the repository to a location of your choosing.
 
 ```bash
-$ mkdir /opt/fireping && cd fireping
+$ sudo mkdir /opt/fireping && cd fireping
 $ sudo git clone https://github.com/jimmycleuren/fireping.git .
 ```
 

--- a/docs/docs/installation/master/fireping.md
+++ b/docs/docs/installation/master/fireping.md
@@ -50,7 +50,7 @@ $ sudo git clone https://github.com/jimmycleuren/fireping.git .
 Now [install Composer](https://getcomposer.org/download/) and fetch the vendor dependencies.
 
 ```bash
-$ composer install --verbose --prefer-dist --no-dev --optimize-autoloader --no-scripts --no-suggest
+$ ./composer.phar install --verbose --prefer-dist --no-dev --optimize-autoloader --no-scripts --no-suggest
 ```
 
 Then, run some post-install scripts.

--- a/docs/docs/installation/slave/fireping.md
+++ b/docs/docs/installation/slave/fireping.md
@@ -33,7 +33,7 @@ $ sudo apt-get install -y php7.4 php7.4-xml php7.4-mysql php7.4-mbstring php7.4-
 Clone the repository to a location of your choosing.
 
 ```bash
-$ mkdir /opt/fireping-slave && cd /opt/fireping-slave
+$ sudo mkdir /opt/fireping-slave && cd /opt/fireping-slave
 $ sudo git clone https://github.com/jimmycleuren/fireping.git .
 ```
 

--- a/docs/docs/installation/slave/fireping.md
+++ b/docs/docs/installation/slave/fireping.md
@@ -40,8 +40,7 @@ $ sudo git clone https://github.com/jimmycleuren/fireping.git .
 Now [install Composer](https://getcomposer.org/download/) and fetch the vendor dependencies.
 
 ```bash
-$ # in /opt/fireping-slave/
-$ composer install --verbose --prefer-dist --no-dev --optimize-autoloader --no-scripts --no-suggest
+$ ./composer.phar install --verbose --prefer-dist --no-dev --optimize-autoloader --no-scripts --no-suggest
 ```
 
 Then, run some post-install scripts.

--- a/docs/docs/installation/slave/fireping.md
+++ b/docs/docs/installation/slave/fireping.md
@@ -16,7 +16,11 @@ Start by adding a new package repository so that we can add the PHP7.4 binaries.
 $ sudo apt-get install -y wget gnupg ca-certificates apt-transport-https
 $ wget -q https://packages.sury.org/php/apt.gpg -O- | sudo apt-key add -
 
-$ echo "deb https://packages.sury.org/php/ stretch main" | sudo tee /etc/apt/sources.list.d/php.list
+# Automatically add for your Debian release. Make sure that https://packages.sury.org/php/dists/ has an entry for your release.
+$ env -i bash -c '. /etc/os-release; echo "deb https://packages.sury.org/php/ $VERSION_CODENAME main"' | sudo tee /etc/apt/sources.list.d/php.list
+# Alternatively, just do it manually for these known supported releases:
+# Debian 9: echo "deb https://packages.sury.org/php/ stretch main" | sudo tee /etc/apt/sources.list.d/php.list
+# Debian 10: echo "deb https://packages.sury.org/php/ buster main" | sudo tee /etc/apt/sources.list.d/php.list
 ```
 
 Then install the required system dependencies.


### PR DESCRIPTION
After feedback from @angeraer, the install docs have been changed as follows:

- Change `composer` to `./composer.phar` because the composer install documentation doesn't tell you to install it in `$PATH` by default.
- Add `sudo` before `mkdir /opt/fireping` and `mkdir /opt/fireping-slave`.
- Automatically determine the Debian release when adding the sury package repository to sources.