### PR TITLE
Set storage.table_storage.table_name to migration_versions.

### DIFF
--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,3 +1,7 @@
 doctrine_migrations:
     migrations_paths:
         'DoctrineMigrations': '%kernel.project_dir%/src/Migrations'
+
+    storage:
+        table_storage:
+            table_name: 'migration_versions'


### PR DESCRIPTION
In the latest doctrine/doctrine-migrations-bundle release this defaults to doctrine_migration_versions.

You also need to run the following command on a master instance or it won't be able to accurately find/keep track of migrations.

```
php bin/console doctrine:migrations:sync-metadata-storage
```