### PR TITLE
Mount a volume into ./var/rrd/test to test RrdCachedStorage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ before_install:
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
   - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
+  - docker inspect rrdcached
+  - ls -al /tmp/fireping/rrd
 
 install:
   - composer -n install --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
-  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -e TZ="Europe/Paris" crazymax/rrdcached
+  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v "${TRAVIS_BUILD_DIR}/var/rrd/test:/data/db" -e TZ="Europe/Paris" crazymax/rrdcached
 
 install:
   - composer -n install --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
+  - echo ${TRAVIS_BUILD_DIR}/var/rrd/test
   - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v ${TRAVIS_BUILD_DIR}/var/rrd/test:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ before_install:
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
   - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
+  - chmod -R 777 /tmp/fireping/rrd
   - docker inspect rrdcached
   - ls -al /tmp/fireping/rrd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
-  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v "${TRAVIS_BUILD_DIR}/var/rrd/test:/data/db" -e TZ="Europe/Paris" crazymax/rrdcached
+  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v ${TRAVIS_BUILD_DIR}/var/rrd/test:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
 
 install:
   - composer -n install --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,8 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
-  - id -u $(whoami)
-  - id -g $(whoami)
-  - id -u $(whoami) && HOST_USERID=$! && echo $HOST_USERID
-  - id -g $(whoami) && HOST_GROUPID=$! && echo $HOST_GROUPID
+  - HOST_USERID=$(id -u $(whoami))
+  - HOST_GROUPID=$(id -g $(whoami))
   - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" -e PUID=$HOST_USERID -e PGID=$HOST_GROUPID crazymax/rrdcached
   - docker inspect rrdcached
   - ls -al /tmp/fireping/rrd

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
   - echo ${TRAVIS_BUILD_DIR}/var/rrd/test
-  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v ${TRAVIS_BUILD_DIR}/var/rrd/test:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
+  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd/test:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
 
 install:
   - composer -n install --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
-  - docker run -d -p 127.0.0.1:42217:42217 -u root --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
+  - id -u $(whoami) && HOST_USERID=$! && echo $HOST_USERID
+  - id -g $(whoami) && HOST_GROUPID=$! && echo $HOST_GROUPID
+  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" -e PUID=$HOST_USERID -e PGID=$HOST_GROUPID crazymax/rrdcached
   - docker inspect rrdcached
   - ls -al /tmp/fireping/rrd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,7 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
-  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
-  - chmod -R 777 /tmp/fireping/rrd
+  - docker run -d -p 127.0.0.1:42217:42217 -u root --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
   - docker inspect rrdcached
   - ls -al /tmp/fireping/rrd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
+  - id -u $(whoami)
+  - id -g $(whoami)
   - id -u $(whoami) && HOST_USERID=$! && echo $HOST_USERID
   - id -g $(whoami) && HOST_GROUPID=$! && echo $HOST_GROUPID
   - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" -e PUID=$HOST_USERID -e PGID=$HOST_GROUPID crazymax/rrdcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
     - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
     - DATABASE_URL=mysql://root@127.0.0.1:3306/fireping_test
     - RRDCACHED_TEST=127.0.0.1:42217
+    - RRD_BASE_PATH=/tmp/fireping/rrd/
 
 language: php
 os: linux
@@ -44,7 +45,6 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
-  - echo ${TRAVIS_BUILD_DIR}/var/rrd/test
   - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd/test:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
     - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
     - DATABASE_URL=mysql://root@127.0.0.1:3306/fireping_test
     - RRDCACHED_TEST=127.0.0.1:42217
-    - RRD_BASE_PATH=/tmp/fireping/rrd/
 
 language: php
 os: linux
@@ -45,7 +44,7 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
-  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd/test:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
+  - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" crazymax/rrdcached
 
 install:
   - composer -n install --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,12 @@ before_install:
   - mkdir build
   - pecl install rrd
   - mysql -e 'CREATE DATABASE fireping_test;'
+  # Setup the rrdcached container.
+  # We are forcing the PUID and PGID of the rrdcached daemon to the same UID/GID of the host so that we can pretend it's
+  # A locally running rrdcached, which for instance RrdCachedStorage assumes it to be.
   - HOST_USERID=$(id -u $(whoami))
   - HOST_GROUPID=$(id -g $(whoami))
   - docker run -d -p 127.0.0.1:42217:42217 --name rrdcached -v /tmp/fireping/rrd:/data/db -e TZ="Europe/Paris" -e PUID=$HOST_USERID -e PGID=$HOST_GROUPID crazymax/rrdcached
-  - docker inspect rrdcached
-  - ls -al /tmp/fireping/rrd
 
 install:
   - composer -n install --prefer-dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     build: docker/php
     volumes:
       - ./:/app
+      - rrd:/app/var/rrd/test
     working_dir: /app
   slave:
     build: docker/slave
@@ -28,6 +29,8 @@ services:
       TZ: "Europe/Paris"
     ports:
       - "42217:42217"
+    volumes:
+      - rrd:/data/db
   db:
     image: mariadb
     ports:
@@ -48,3 +51,6 @@ services:
       MYSQL_DATABASE: fireping_test
       MYSQL_USER: fireping
       MYSQL_PASSWORD: fireping
+
+volumes:
+  rrd:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     build: docker/php
     volumes:
       - ./:/app
-      - rrd:/app/var/rrd/test
+      - rrd:/tmp/fireping/rrd/
     working_dir: /app
   slave:
     build: docker/slave

--- a/src/Storage/RrdCachedStorage.php
+++ b/src/Storage/RrdCachedStorage.php
@@ -352,7 +352,6 @@ class RrdCachedStorage extends RrdStorage
 
     protected function addDataSource(Device $device, $filename, $name, Probe $probe)
     {
-        dump("Adding datasource $name to $filename");
         $ds = sprintf(
             "DS:%s:%s:%s:%s:%s",
             $name,
@@ -364,12 +363,10 @@ class RrdCachedStorage extends RrdStorage
 
         $process = new Process(['ls', '-al', '/tmp/fireping/rrd']);
         $process->run();
-        dump(['out' => $process->getOutput(), 'err' => $process->getErrorOutput(), 'path' => $this->path . $filename]);
 
         $process = new Process(["rrdtool", "tune", $this->path.$filename, $ds]);
         $process->run();
         $error = $process->getErrorOutput();
-        dump(['out' => $process->getOutput(), 'err' => $process->getErrorOutput(), 'path' => $this->path . $filename]);
 
         if ($error) {
             throw new RrdException(trim($error));

--- a/src/Storage/RrdCachedStorage.php
+++ b/src/Storage/RrdCachedStorage.php
@@ -352,6 +352,7 @@ class RrdCachedStorage extends RrdStorage
 
     protected function addDataSource(Device $device, $filename, $name, Probe $probe)
     {
+        dump("Adding datasource $name to $filename");
         $ds = sprintf(
             "DS:%s:%s:%s:%s:%s",
             $name,
@@ -368,6 +369,7 @@ class RrdCachedStorage extends RrdStorage
         $process = new Process(["rrdtool", "tune", $this->path.$filename, $ds]);
         $process->run();
         $error = $process->getErrorOutput();
+        dump(['out' => $process->getOutput(), 'err' => $process->getErrorOutput(), 'path' => $this->path . $filename]);
 
         if ($error) {
             throw new RrdException(trim($error));

--- a/src/Storage/RrdCachedStorage.php
+++ b/src/Storage/RrdCachedStorage.php
@@ -361,6 +361,10 @@ class RrdCachedStorage extends RrdStorage
             "U"
         );
 
+        $process = new Process(['ls', '-al', '/tmp/fireping/rrd']);
+        $process->run();
+        dump(['out' => $process->getOutput(), 'err' => $process->getErrorOutput(), 'path' => $this->path . $filename]);
+
         $process = new Process(["rrdtool", "tune", $this->path.$filename, $ds]);
         $process->run();
         $error = $process->getErrorOutput();

--- a/tests/App/Storage/RrdCachedStorageTest.php
+++ b/tests/App/Storage/RrdCachedStorageTest.php
@@ -25,7 +25,9 @@ class RrdCachedStorageTest extends TestCase
     {
         $logger = $this->prophesize(LoggerInterface::class)->reveal();
 
-        $storage = new RrdCachedStorage(null, $logger);
+        $path = realpath(__DIR__.'/../../../var/rrd/test') . '/';
+
+        $storage = new RrdCachedStorage($path, $logger);
 
         $device = new Device();
         $device->setId(1);
@@ -52,7 +54,9 @@ class RrdCachedStorageTest extends TestCase
     {
         $logger = $this->prophesize(LoggerInterface::class)->reveal();
 
-        $storage = new RrdCachedStorage(null, $logger);
+        $path = realpath(__DIR__.'/../../../var/rrd/test') . '/';
+
+        $storage = new RrdCachedStorage($path, $logger);
 
         $device = new Device();
         $device->setId(1);
@@ -79,7 +83,9 @@ class RrdCachedStorageTest extends TestCase
     {
         $logger = $this->prophesize(LoggerInterface::class)->reveal();
 
-        $storage = new RrdCachedStorage(null, $logger);
+        $path = realpath(__DIR__.'/../../../var/rrd/test') . '/';
+
+        $storage = new RrdCachedStorage($path, $logger);
 
         $device = new Device();
         $device->setId(1);
@@ -100,9 +106,6 @@ class RrdCachedStorageTest extends TestCase
 
         $datasources = $storage->getDatasources($device, $probe, $group, $_ENV['RRDCACHED_TEST'] ?? "127.0.0.1:42217");
 
-        //TODO: this is correct, but we cannot rrdtune over ssh connections in the test suite
-        //$this->assertEquals(["median", "loss", "new"], $datasources);
-
-        $this->assertEquals(["median", "loss"], $datasources);
+        $this->assertEquals(["median", "loss", "new"], $datasources);
     }
 }

--- a/tests/App/Storage/RrdCachedStorageTest.php
+++ b/tests/App/Storage/RrdCachedStorageTest.php
@@ -25,7 +25,7 @@ class RrdCachedStorageTest extends TestCase
     {
         $logger = $this->prophesize(LoggerInterface::class)->reveal();
 
-        $path = realpath(__DIR__.'/../../../var/rrd/test') . '/';
+        $path = realpath('/tmp/fireping/rrd') . '/';
 
         $storage = new RrdCachedStorage($path, $logger);
 
@@ -54,7 +54,7 @@ class RrdCachedStorageTest extends TestCase
     {
         $logger = $this->prophesize(LoggerInterface::class)->reveal();
 
-        $path = realpath(__DIR__.'/../../../var/rrd/test') . '/';
+        $path = realpath('/tmp/fireping/rrd/') . '/';
 
         $storage = new RrdCachedStorage($path, $logger);
 
@@ -83,7 +83,7 @@ class RrdCachedStorageTest extends TestCase
     {
         $logger = $this->prophesize(LoggerInterface::class)->reveal();
 
-        $path = realpath(__DIR__.'/../../../var/rrd/test') . '/';
+        $path = realpath('/tmp/fireping/rrd') . '/';
 
         $storage = new RrdCachedStorage($path, $logger);
 


### PR DESCRIPTION
This works locally, question is if it'll work on Travis. Basically, RrdCachedStorage *expects* the daemon to be running locally. Obviously, we aren't doing that on Travis nor on our local docker-compose stack, so this is a workaround. We first create a volume, then mount that named volume into both the php and rrdcached containers. As we create files into the rrdcached container, they'll be shared to the PHP container as-if they were local.

It took some blood, sweat and tears to get this working, and it's dirty as hell, but it works. We'll do something better at a later date. At least we don't have to remove the test this way just to stop it being flaky.