### PR TITLE
Add demo link.

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,4 +1,6 @@
 header:
+  - title: Demo 🚀
+    url: http://demo.fireping.com
   - title: GitHub
     url: https://github.com/jimmycleuren/fireping
 


### PR DESCRIPTION
This PR adds a link to the header of our documentation that leads to a demo install of Fireping.