### PR TITLE
Calculate time once per dispatching cycle.

### DIFF
--- a/src/Command/ProbeDispatcherCommand.php
+++ b/src/Command/ProbeDispatcherCommand.php
@@ -175,7 +175,9 @@ class ProbeDispatcherCommand extends Command
         $this->loop = Factory::create();
 
         $this->loop->addPeriodicTimer(1, function () {
-            if (time() % 120 === $this->randomFactor) {
+            $now = time();
+
+            if ($now % 120 === $this->randomFactor) {
                 $instruction = [
                     'type' => GetConfigHttpWorkerCommand::class,
                     'delay_execution' => 0,
@@ -184,7 +186,7 @@ class ProbeDispatcherCommand extends Command
                 $this->sendInstruction($instruction);
             }
 
-            if (time() % 60 === (int) floor($this->randomFactor / 2)) {
+            if ($now % 60 === (int) floor($this->randomFactor / 2)) {
                 $instruction = [
                     'type' => PostStatsHttpWorkerCommand::class,
                     'delay_execution' => 0,
@@ -198,7 +200,7 @@ class ProbeDispatcherCommand extends Command
             }
 
             foreach ($this->configuration->getProbes() as $probe) {
-                $ready = 0 === time() % $probe->getStep();
+                $ready = 0 === $now % $probe->getStep();
 
                 if ($ready) {
                     $instructions = new Instruction($probe, $this->devicesPerWorker);

--- a/src/Command/ProbeDispatcherCommand.php
+++ b/src/Command/ProbeDispatcherCommand.php
@@ -212,10 +212,7 @@ class ProbeDispatcherCommand extends Command
                         $delay = $counter % $probe->getSampleRate();
                         ++$counter;
                         $instruction['delay_execution'] = $delay;
-                        $this->sendInstruction(
-                            $instruction,
-                            $probe->getStep()
-                        );
+                        $this->sendInstruction($instruction, $probe->getStep());
                     }
                 }
             }

--- a/src/Command/ProbeDispatcherCommand.php
+++ b/src/Command/ProbeDispatcherCommand.php
@@ -142,8 +142,8 @@ class ProbeDispatcherCommand extends Command
         }
 
         $this->workerManager->initialize(
-            intval($input->getOption('workers')),
-            intval($input->getOption('maximum-workers')),
+            (int) $input->getOption('workers'),
+            (int) $input->getOption('maximum-workers'),
             $this->numberOfQueues
         );
 

--- a/src/Command/ProbeDispatcherCommand.php
+++ b/src/Command/ProbeDispatcherCommand.php
@@ -182,6 +182,7 @@ class ProbeDispatcherCommand extends Command
                     'type' => GetConfigHttpWorkerCommand::class,
                     'delay_execution' => 0,
                     'etag' => $this->configuration->getEtag(),
+                    'timestamp' => $now,
                 ];
                 $this->sendInstruction($instruction);
             }
@@ -191,6 +192,7 @@ class ProbeDispatcherCommand extends Command
                     'type' => PostStatsHttpWorkerCommand::class,
                     'delay_execution' => 0,
                     'body' => $this->statsManager->getStats(),
+                    'timestamp' => $now,
                 ];
                 $this->sendInstruction($instruction, 30);
             }
@@ -212,6 +214,7 @@ class ProbeDispatcherCommand extends Command
                         $delay = $counter % $probe->getSampleRate();
                         ++$counter;
                         $instruction['delay_execution'] = $delay;
+                        $instruction['timestamp'] = $now;
                         $this->sendInstruction($instruction, $probe->getStep());
                     }
                 }

--- a/src/Command/ProbeDispatcherCommand.php
+++ b/src/Command/ProbeDispatcherCommand.php
@@ -212,7 +212,6 @@ class ProbeDispatcherCommand extends Command
                         $delay = $counter % $probe->getSampleRate();
                         ++$counter;
                         $instruction['delay_execution'] = $delay;
-                        $instruction['guid'] = sha1(random_bytes(25));
                         $this->sendInstruction(
                             $instruction,
                             $probe->getStep()

--- a/src/Command/ProbeWorkerCommand.php
+++ b/src/Command/ProbeWorkerCommand.php
@@ -121,10 +121,24 @@ class ProbeWorkerCommand extends Command
      */
     protected function process(string $data)
     {
+        $startOfWork = time();
         $data = json_decode($data, true);
         $timestamp = $data['timestamp'] ?? null;
 
         if ($timestamp === null || !is_int($timestamp)) {
+            $this->sendResponse([
+                'type' => 'exception',
+                'status' => 400,
+                'body' => [
+                    'timestamp' => $timestamp,
+                    'contents' => 'Missing timestamp',
+                ],
+                'debug' => [
+                    'runtime' => time() - $startOfWork,
+                    'request' => $data,
+                    'pid' => getmypid(),
+                ],
+            ]);
             throw new \RuntimeException('missing or invalid timestamp');
         }
 
@@ -138,7 +152,7 @@ class ProbeWorkerCommand extends Command
                         'contents' => 'Invalid JSON Received.',
                     ],
                     'debug' => [
-                        'runtime' => time() - $timestamp,
+                        'runtime' => time() - $startOfWork,
                         'request' => $data,
                         'pid' => getmypid(),
                     ],
@@ -158,7 +172,7 @@ class ProbeWorkerCommand extends Command
                         'contents' => 'Command type missing.',
                     ],
                     'debug' => [
-                        'runtime' => time() - $timestamp,
+                        'runtime' => time() - $startOfWork,
                         'request' => $data,
                         'pid' => getmypid(),
                     ],
@@ -184,7 +198,7 @@ class ProbeWorkerCommand extends Command
                         'contents' => $e->getMessage(),
                     ],
                     'debug' => [
-                            'runtime' => time() - $timestamp,
+                            'runtime' => time() - $startOfWork,
                             'request' => $data,
                             'pid' => getmypid(),
                     ],
@@ -212,7 +226,7 @@ class ProbeWorkerCommand extends Command
                             'raw' => $shellOutput,
                         ],
                         'debug' => [
-                            'runtime' => time() - $timestamp,
+                            'runtime' => time() - $startOfWork,
                             'pid' => getmypid(),
                         ],
                     ]);
@@ -231,7 +245,7 @@ class ProbeWorkerCommand extends Command
                             'contents' => $shellOutput['contents'],
                         ],
                         'debug' => [
-                            'runtime' => time() - $timestamp,
+                            'runtime' => time() - $startOfWork,
                             'pid' => getmypid(),
                         ],
                     ]);
@@ -254,7 +268,7 @@ class ProbeWorkerCommand extends Command
                             ],
                         ],
                         'debug' => [
-                            'runtime' => time() - $timestamp,
+                            'runtime' => time() - $startOfWork,
                             //'request' => $data,
                             'pid' => getmypid(),
                         ],
@@ -270,7 +284,7 @@ class ProbeWorkerCommand extends Command
                                 'contents' => 'No answer defined for '.$data['type'],
                             ],
                             'debug' => [
-                                'runtime' => time() - $timestamp,
+                                'runtime' => time() - $startOfWork,
                                 'request' => $data,
                                 'pid' => getmypid(),
                             ],
@@ -287,7 +301,7 @@ class ProbeWorkerCommand extends Command
                         'contents' => $e->getMessage().' on '.$e->getFile().':'.$e->getLine(),
                     ],
                     'debug' => [
-                        'runtime' => time() - $timestamp,
+                        'runtime' => time() - $startOfWork,
                         'request' => $data,
                         'pid' => getmypid(),
                     ],

--- a/src/Command/ProbeWorkerCommand.php
+++ b/src/Command/ProbeWorkerCommand.php
@@ -139,7 +139,6 @@ class ProbeWorkerCommand extends Command
                     'pid' => getmypid(),
                 ],
             ]);
-            throw new \RuntimeException('missing or invalid timestamp');
         }
 
         if (!$data) {

--- a/src/Command/ProbeWorkerCommand.php
+++ b/src/Command/ProbeWorkerCommand.php
@@ -121,29 +121,12 @@ class ProbeWorkerCommand extends Command
      */
     protected function process(string $data)
     {
-        $timestamp = time();
-
-        if (!trim($data)) {
-            $this->sendResponse(
-                [
-                    'type' => 'exception',
-                    'status' => 400,
-                    'body' => [
-                        'timestamp' => $timestamp,
-                        'contents' => 'Input data not received.',
-                    ],
-                    'debug' => [
-                        'runtime' => time() - $timestamp,
-                        'request' => $data,
-                        'pid' => getmypid(),
-                    ],
-                ]
-            );
-
-            return;
-        }
-
         $data = json_decode($data, true);
+        $timestamp = $data['timestamp'] ?? null;
+
+        if ($timestamp === null || !is_int($timestamp)) {
+            throw new \RuntimeException('missing or invalid timestamp');
+        }
 
         if (!$data) {
             $this->sendResponse(


### PR DESCRIPTION
As discovered earlier, we were missing some beats if a cycle lasted for longer than one second. This *should* fix it.