### PR TITLE
Fix long domain names crossing the sidebar

### DIFF
--- a/src/Controller/SidebarController.php
+++ b/src/Controller/SidebarController.php
@@ -2,13 +2,36 @@
 
 namespace App\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use KevinPapst\AdminLTEBundle\Controller\SidebarController as AdminLteSidebarController;
+use KevinPapst\AdminLTEBundle\Event\SidebarMenuEvent;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
-class SidebarController extends AbstractController
+class SidebarController extends AdminLteSidebarController
 {
     public function settingsAction(Request $originalRequest)
     {
         return $this->render('sidebar/settings.html.twig');
+    }
+
+    /**
+     * @param Request $request
+     * @return Response
+     */
+    public function menuAction(Request $request): Response
+    {
+        if (!$this->hasListener(SidebarMenuEvent::class)) {
+            return new Response();
+        }
+
+        /** @var SidebarMenuEvent $event */
+        $event = $this->dispatch(new SidebarMenuEvent($request));
+
+        return $this->render(
+            'sidebar/menu.html.twig',
+            [
+                'menu' => $event->getItems(),
+            ]
+        );
     }
 }

--- a/src/EventSubscriber/MenuBuilderSubscriber.php
+++ b/src/EventSubscriber/MenuBuilderSubscriber.php
@@ -75,7 +75,7 @@ class MenuBuilderSubscriber implements EventSubscriberInterface
     {
         $event = $this->addStaticMenu($event);
 
-        $domains = $this->domainRepository->findByParent(null);
+        $domains = $this->domainRepository->findBy(['parent' => null]);
 
         if (count($domains) > 0) {
             $title = new MenuItemModel('domains', 'Root domains', '');

--- a/templates/base-adminlte.html.twig
+++ b/templates/base-adminlte.html.twig
@@ -10,6 +10,14 @@
 {% block logo_mini %}FP{% endblock %}
 {% block logo_large %}Fireping{% endblock %}
 
+{% block sidebar_nav %}
+    {% if admin_lte_context.knp_menu.enable %}
+        {% include '@AdminLTE/Sidebar/knp-menu.html.twig' %}
+    {% else %}
+        {{ render(controller('App\\Controller\\SidebarController::menuAction', {'request':app.request})) }}
+    {% endif %}
+{% endblock %}
+
 {% block javascripts %}
     {{ parent() }}
     <script src="{{ asset('js/q-5.0.2.min.js') }}"></script>

--- a/templates/macros/menu.html.twig
+++ b/templates/macros/menu.html.twig
@@ -1,0 +1,49 @@
+{% macro menu_item(item) %}
+    {% import _self as menu %}
+    {% if item.route or item.hasChildren %}
+        <li id="{{ item.identifier }}" class=" {{ item.isActive ? 'active' : '' }} {{ item.hasChildren? 'treeview' : '' }}">
+            <a style="padding: 12px 15px;" href="{{ item.hasChildren ? '#': '/' in item.route ? item.route : path(item.route|route_alias, item.routeArgs) }}">
+                <div style="display: flex; align-items: center; justify-content: space-between">
+                    <div>
+                        {% if item.icon %} <i class="{{ item.icon }} fa-fw"></i> {% endif %}
+                        {% if item.hasChildren %}<i class="fas fa-angle-left pull-right"></i>{% endif %}
+                        <span style="white-space: break-spaces">{{ item.label|trans }}</span>
+                    </div>
+                    {% if item.badge is not same as(false) %}
+                        <div>
+                            <small class="label pull-right bg-{{ item.badgeColor }}">{{ item.badge }}</small>
+                        </div>
+                    {% endif %}
+                </div>
+            </a>
+
+            {% if item.hasChildren %}
+                <ul class="treeview-menu">
+                    {% for child in item.children %}
+                        {% if child.hasChildren %}
+                            {{ menu.menu_item(child) }}
+                        {% else %}
+                            <li class="{{ child.isActive ? 'active':'' }}" id="{{ child.identifier }}">
+                                <a href="{{ '/' in child.route ? child.route : path(child.route|route_alias, child.routeArgs) }}">
+                                    {{ menu.menu_item_content(child, '') }}
+                                </a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        </li>
+    {% else %}
+        <li id="{{ item.identifier }}" class="header">
+            {{ menu.menu_item_content(item, '') }}
+        </li>
+    {% endif %}
+{% endmacro %}
+
+{% macro menu_item_content(item, defaultIcon) %}
+    <i class="{{ item.icon|default(defaultIcon) }}"></i>
+    <span>{{ item.label|trans }}</span>
+    {% if item.badge is not same as(false) %}
+        <small class="label pull-right bg-{{ item.badgeColor }}">{{ item.badge }}</small>
+    {% endif %}
+{% endmacro %}

--- a/templates/macros/menu.html.twig
+++ b/templates/macros/menu.html.twig
@@ -1,3 +1,4 @@
+{# backported from @AdminLTEBundle/Resources/Macros/menu.html.twig #}
 {% macro menu_item(item) %}
     {% import _self as menu %}
     {% if item.route or item.hasChildren %}

--- a/templates/sidebar/menu.html.twig
+++ b/templates/sidebar/menu.html.twig
@@ -1,0 +1,7 @@
+{# backported from @AdminLTE/Sidebar/menu.html.twig #}
+{% from "macros/menu.html.twig" import menu_item %}
+<ul class="sidebar-menu" data-widget="tree">
+    {% for item in menu %}
+        {{ menu_item(item) }}
+    {% endfor %}
+</ul>


### PR DESCRIPTION
Okay, so the AdminLTEBundle doesn't really allow fixing this by default, so I had to backport their implementation with our own fixes, and then make sure we render our own templates in the right places.

It looks like this now. I'm having difficult lining the text on the same column, but it already solves the immediate problem of the text crossing the sidebar container.

![image](https://user-images.githubusercontent.com/22906111/86598901-21bd1800-bf9e-11ea-8fcd-07c16143d784.png)

This fixes #352.