### PR TITLE
Write logs to stderr instead of local files.

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -6,17 +6,19 @@ monolog:
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
             channels: ["!event"]
-        alert:
-            type: stream
-            path:  "%kernel.logs_dir%/alert.%kernel.environment%.log"
+        # uncomment to get logging in your browser
+        # you may have to allow bigger header sizes in your Web server configuration
+        #firephp:
+        #    type: firephp
+        #    level: info
+        #chromephp:
+        #    type: chromephp
+        #    level: info
+        syslog_handler:
+            type: syslog
             level: info
             channels: [alert]
         console:
             type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine", "!console"]
-            level: info
-        syslog_handler:
-            type: syslog
-            level: info
-            channels: [alert]

--- a/config/packages/prod/deprecations.yaml
+++ b/config/packages/prod/deprecations.yaml
@@ -1,8 +1,8 @@
 # As of Symfony 5.1, deprecations are logged in the dedicated "deprecation" channel when it exists
-#monolog:
-#    channels: [deprecation]
-#    handlers:
-#        deprecation:
-#            type: stream
-#            channels: [deprecation]
-#            path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+monolog:
+    channels: [deprecation]
+    handlers:
+        deprecation:
+            type: stream
+            channels: [deprecation]
+            path: php://stderr

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -2,17 +2,20 @@ monolog:
     channels: ["alert"]
     handlers:
         main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_http_codes: [404, 405]
+            buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+        nested:
             type: stream
-            path: '%kernel.logs_dir%/%kernel.environment%.log'
-            level: info
-        alert:
-            type: stream
-            path:  "%kernel.logs_dir%/alert.%kernel.environment%.log"
-            level: info
-            channels: [alert]
-        console:
-            type: console
+            path: php://stderr
+            level: debug
         syslog_handler:
             type: syslog
             level: info
-            channels: [alert]
+            channels: [ alert ]
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine"]

--- a/config/packages/slave/monolog.yaml
+++ b/config/packages/slave/monolog.yaml
@@ -2,11 +2,16 @@ monolog:
     channels: ["alert"]
     handlers:
         main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_http_codes: [404, 405]
+            buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+        nested:
             type: stream
-            path: '%kernel.logs_dir%/%kernel.environment%.log'
-            level: info
-        alert:
-            type: stream
-            path:  "%kernel.logs_dir%/alert.%kernel.environment%.log"
-            level: info
-            channels: [alert]
+            path: php://stderr
+            level: debug
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: [ "!event", "!doctrine" ]

--- a/config/packages/test/monolog.yaml
+++ b/config/packages/test/monolog.yaml
@@ -2,7 +2,12 @@ monolog:
     channels: ["alert"]
     handlers:
         main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_http_codes: [404, 405]
+            channels: ["!event"]
+        nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
-            channels: ["!event"]


### PR DESCRIPTION
This PR changes the current logging configuration to be more in line with modern Symfony recommendations by logging to stderr instead.

Everything still works fine in my local environment after this change. I've also left the syslog_handler in there for VM setups that would still use it, it's irrelevant for docker setups though.

With docker containers, you can just do `docker logs CONTAINER` and can configure your own containers however you want to send them to files, fluentd, other services, ...etc.

I also activated deprecation logs, which has already revealed some issues we need to take care of. :-)

More info: https://symfony.com/blog/logging-in-symfony-and-the-cloud
This is also part of the default recipes now.

Closes #632 