### PR TITLE
Move fixtures to the dev autoloaded namespace only.

### DIFF
--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -70,6 +70,9 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress --no-suggest
 
+      - name: Dump Autoload (composer)
+        run: composer dump-autoload --optimize
+
       - name: Install phpunit
         run: ./vendor/bin/simple-phpunit install
 

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
     "type": "project",
     "autoload": {
         "psr-4": {
-            "App\\": "src/",
-            "App\\DataFixtures\\": "fixtures/"
+            "App\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "App\\Tests\\": "tests/"
+            "App\\Tests\\": "tests/",
+            "App\\DataFixtures\\": "fixtures/"
         }
     },
     "require": {


### PR DESCRIPTION
There is no need for these fixtures to be loaded on production environments.