### PR TITLE
Fix: define alert channel in slave\monolog.yaml

### DIFF
--- a/config/packages/slave/monolog.yaml
+++ b/config/packages/slave/monolog.yaml
@@ -1,4 +1,5 @@
 monolog:
+    channel: ['alert']
     handlers:
         main:
             type: fingers_crossed


### PR DESCRIPTION
Because services.yaml still gets loaded in the current Kernel.php, we still need the channel for now.

This will be fixed in a future PR where we will no longer rely on services.yaml at all.