### PR TITLE
Remove unnecessary empty condition.

### DIFF
--- a/src/Slave/Task/FetchConfiguration.php
+++ b/src/Slave/Task/FetchConfiguration.php
@@ -49,10 +49,6 @@ class FetchConfiguration implements TaskInterface
                 return ['code' => 500, 'contents' => 'Malformed JSON', 'etag' => $eTag];
             }
 
-            if (empty($configuration)) {
-                return ['code' => 201, 'contents' => 'Configuration empty', 'etag' => $eTag];
-            }
-
             return ['code' => 200, 'contents' => $configuration, 'etag' => $eTag];
         } catch (GuzzleException $exception) {
             return ['code' => 500, 'contents' => $exception->getMessage(), 'etag' => null];


### PR DESCRIPTION
This code doesn't really serve a purpose anyway. Even if the configuration is empty, it'll just send an empty array back from the `execute()` method into the Worker and finally get serialized as JSON back to the Dispatcher where it'll just be handled as expected.

Just removing it is the best solution.

This fixes #714 