### PR TITLE
Require PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-json": "*",
         "ext-rrd": "*",
         "api-platform/api-pack": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "177704120262820ca4a59099b8fdc19b",
+    "content-hash": "cca9d7c96e2ec3c57dfedce09274a9d9",
     "packages": [
         {
             "name": "api-platform/api-pack",
@@ -10492,7 +10492,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-json": "*",
         "ext-rrd": "*"
     },


### PR DESCRIPTION
PHP 7.3 is no longer supported, so I think it's high time we promote our base requirement to PHP 7.4 instead.

In 6 months time 7.4 will also leave active support, at which point we should make our minimal version 8.0.