### PR TITLE
Remove prophesize integration in our test-suite

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -41,7 +41,7 @@ services:
         public: true
 
     App\AlertDestination\Mail:
-        arguments: ["@swiftmailer.mailer.default", "@monolog.logger", "@twig"]
+        arguments: ["@swiftmailer.mailer.default", "@monolog.logger", "@twig", "%env(MAILER_FROM)%"]
         public: true
 
     App\Storage\RrdStorage:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -33,7 +33,7 @@ services:
         public: true
 
     App\AlertDestination\Http:
-        arguments: ["@eight_points_guzzle.client.alert", "@monolog.logger"]
+        arguments: ["@eight_points_guzzle.client.alert"]
         public: true
 
     App\AlertDestination\Slack:

--- a/src/Exception/ClearException.php
+++ b/src/Exception/ClearException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Exception;
+
+class ClearException extends \RuntimeException
+{
+
+}

--- a/src/Exception/TriggerException.php
+++ b/src/Exception/TriggerException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Exception;
+
+class TriggerException extends \RuntimeException
+{
+
+}

--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -57,7 +57,11 @@ abstract class Processor
                             $alert->setFirstseen(new \DateTime());
                             $destinations = $device->getActiveAlertDestinations();
                             foreach ($destinations as $destination) {
-                                $this->alertDestinationFactory->create($destination)->trigger($alert);
+                                try {
+                                    $this->alertDestinationFactory->create($destination)->trigger($alert);
+                                } catch (TriggerException $exception) {
+                                    $this->logger->error("failed to trigger alert at destination $destination because: {$exception->getMessage()}");
+                                }
                             }
                         }
                         $alert->setLastseen(new \DateTime());
@@ -74,7 +78,11 @@ abstract class Processor
                             //$this->em->persist($alert); //flush will be done in slavecontroller
                             $destinations = $device->getActiveAlertDestinations();
                             foreach ($destinations as $destination) {
-                                $this->alertDestinationFactory->create($destination)->clear($alert);
+                                try {
+                                    $this->alertDestinationFactory->create($destination)->clear($alert);
+                                } catch (ClearException $exception) {
+                                    $this->logger->error("failed to clear alert at destination $destination because: {$exception->getMessage()}");
+                                }
                             }
                             $this->em->remove($alert); //flush will be done in slavecontroller
                         }


### PR DESCRIPTION
I firmly believe that when we're mocking all of our classes dependencies we aren't really testing anything. In this PR I'll try to remove all of the ->prophesize usage with actual mocks or just running it through real dependencies.

This has the added benefit that in PHPunit 9 they've also removed prophecy from core.