### PR TITLE
Remove deprecated metadata_cache_driver.

### DIFF
--- a/config/packages/prod/doctrine.yaml
+++ b/config/packages/prod/doctrine.yaml
@@ -1,9 +1,6 @@
 doctrine:
     orm:
         auto_generate_proxy_classes: false
-        metadata_cache_driver:
-            type: pool
-            pool: doctrine.system_cache_pool
         query_cache_driver:
             type: pool
             pool: doctrine.system_cache_pool


### PR DESCRIPTION
This is no longer in use since 3.2 (see https://github.com/doctrine/DoctrineBundle/blob/2.4.x/UPGRADE-2.3.md) and it is why #775 fails because it has been removed in the subsequent version.