### PR TITLE
Refactor Dispatcher & Worker

### DIFF
--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -138,18 +138,17 @@ final class ProbeDispatcherCommand extends Command
             ]);
         });
 
+        Loop::addPeriodicTimer(60, function () {
+            $this->sendInstruction([
+                'type' => PublishStatistics::class,
+                'delay_execution' => 0,
+                'body' => $this->statsManager->getStats(),
+                'timestamp' => time(),
+            ]);
+        });
+
         $this->loop->addPeriodicTimer(1, function () {
             $now = time();
-
-            if ($now % 60 === (int) floor($this->randomFactor / 2)) {
-                $instruction = [
-                    'type' => PublishStatistics::class,
-                    'delay_execution' => 0,
-                    'body' => $this->statsManager->getStats(),
-                    'timestamp' => $now,
-                ];
-                $this->sendInstruction($instruction, 30);
-            }
 
             foreach ($this->queues as $queue) {
                 $queue->loop();

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -194,7 +194,7 @@ final class ProbeDispatcherCommand extends Command
             });
         }
 
-        $this->loop->run();
+        Loop::run();
 
         return 0;
     }

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -129,18 +129,17 @@ final class ProbeDispatcherCommand extends Command
 
         $this->loop = Loop::get();
 
+        Loop::addPeriodicTimer(120, function () {
+            $this->sendInstruction([
+                'type' => FetchConfiguration::class,
+                'delay_execution' => 0,
+                'etag' => $this->configuration->getEtag(),
+                'timestamp' => time(),
+            ]);
+        });
+
         $this->loop->addPeriodicTimer(1, function () {
             $now = time();
-
-            if ($now % 120 === $this->randomFactor) {
-                $instruction = [
-                    'type' => FetchConfiguration::class,
-                    'delay_execution' => 0,
-                    'etag' => $this->configuration->getEtag(),
-                    'timestamp' => $now,
-                ];
-                $this->sendInstruction($instruction);
-            }
 
             if ($now % 60 === (int) floor($this->randomFactor / 2)) {
                 $instruction = [

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use function time;
 use const INF;
 
 final class ProbeDispatcherCommand extends Command
@@ -166,7 +167,7 @@ final class ProbeDispatcherCommand extends Command
             }
         });
 
-        $this->loop->addPeriodicTimer(1, function () {
+        Loop::addPeriodicTimer(1, function () {
             $now = time();
 
             foreach ($this->configuration->getProbes() as $probe) {

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -15,7 +15,7 @@ use App\Slave\Worker\StatsManager;
 use App\Slave\Worker\WorkerManager;
 use Exception;
 use Psr\Log\LoggerInterface;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -127,7 +127,7 @@ final class ProbeDispatcherCommand extends Command
         $this->logger->info('Slave url is '.$_ENV['SLAVE_URL']);
         $this->logger->info('Random factor is '.$this->randomFactor);
 
-        $this->loop = Factory::create();
+        $this->loop = Loop::get();
 
         $this->loop->addPeriodicTimer(1, function () {
             $now = time();

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -26,6 +26,7 @@ use function time;
 final class ProbeDispatcherCommand extends Command
 {
     public const DEFAULT_NUMBER_OF_QUEUES = 10;
+    public const DEVICES_PER_WORKER = 250;
 
     /**
      * @var Queue[]
@@ -42,7 +43,6 @@ final class ProbeDispatcherCommand extends Command
     private int $maxRuntime = 0;
     private WorkerManager $workerManager;
     private StatsManager $statsManager;
-    private int $devicesPerWorker = 250;
 
     public function __construct(LoggerInterface $logger, WorkerManager $workerManager, StatsManager $statsManager)
     {
@@ -166,7 +166,7 @@ final class ProbeDispatcherCommand extends Command
                 $ready = 0 === $now % $probe->getStep();
 
                 if ($ready) {
-                    $instructions = new Instruction($probe, $this->devicesPerWorker);
+                    $instructions = new Instruction($probe, self::DEVICES_PER_WORKER);
 
                     // Keep track of how many processes are starting.
                     $counter = 0;
@@ -286,7 +286,7 @@ final class ProbeDispatcherCommand extends Command
 
                     $count = 0;
                     foreach ($this->configuration->getProbes() as $probe) {
-                        $count += ceil($this->configuration->getProbeDeviceCount($probe->getId()) / $this->devicesPerWorker);
+                        $count += ceil($this->configuration->getProbeDeviceCount($probe->getId()) / self::DEVICES_PER_WORKER);
                     }
                     $this->workerManager->setNumberOfProbeProcesses(intval($count));
                 } else {

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -156,6 +156,10 @@ final class ProbeDispatcherCommand extends Command
             );
         });
 
+        Loop::addPeriodicTimer(0.1, function () {
+            $this->workerManager->loop();
+        });
+
         $this->loop->addPeriodicTimer(1, function () {
             $now = time();
 
@@ -181,10 +185,6 @@ final class ProbeDispatcherCommand extends Command
                     }
                 }
             }
-        });
-
-        $this->loop->addPeriodicTimer(0.1, function () {
-            $this->workerManager->loop();
         });
 
         if ($this->maxRuntime > 0) {

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -18,67 +18,33 @@ use Psr\Log\LoggerInterface;
 use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
-/**
- * Class ProbeDispatcherCommand.
- */
-class ProbeDispatcherCommand extends Command
+final class ProbeDispatcherCommand extends Command
 {
-    /**
-     * The number of queues that will be created by the ProbeDispatcher.
-     *
-     * @var int
-     */
-    protected $numberOfQueues = 10;
+    private int $numberOfQueues = 10;
 
     /**
-     * A collection of queues available to the ProbeDispatcher.
-     *
      * @var Queue[]
      */
-    protected $queues;
+    private array $queues = [];
 
-    /**
-     * Used to write to log files.
-     *
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
-     * Holds the configuration of our Fireping Slave.
-     *
-     * @var Configuration
-     */
-    protected $configuration;
+    private LoggerInterface $logger;
+    private Configuration $configuration;
 
     /**
      * How long the ProbeDispatcher can run for, in seconds. You can specify 0 to
      * indicate an infinitely running process.
-     *
-     * @var int
      */
-    protected $maxRuntime;
-
-    /**
-     * The LoopInterface that runs our process.
-     *
-     * @var LoopInterface
-     */
-    protected $loop;
-
-    private $workerManager;
-
-    private $statsManager;
-
-    private $devicesPerWorker = 250;
-
-    private $randomFactor = 0;
+    private int $maxRuntime = 0;
+    private LoopInterface $loop;
+    private WorkerManager $workerManager;
+    private StatsManager $statsManager;
+    private int $devicesPerWorker = 250;
+    private int $randomFactor = 0;
 
     public function __construct(LoggerInterface $logger, WorkerManager $workerManager, StatsManager $statsManager)
     {
@@ -89,11 +55,6 @@ class ProbeDispatcherCommand extends Command
         parent::__construct();
     }
 
-    /**
-     * Configure our command.
-     *
-     * @throws InvalidArgumentException
-     */
     protected function configure(): void
     {
         $this
@@ -122,10 +83,6 @@ class ProbeDispatcherCommand extends Command
             );
     }
 
-    /**
-     * @throws \RuntimeException
-     * @throws InvalidArgumentException
-     */
     private function setUp(InputInterface $input)
     {
         $this->maxRuntime = (int) $input->getOption('max-runtime');
@@ -248,7 +205,7 @@ class ProbeDispatcherCommand extends Command
     /**
      * @throws Exception
      */
-    public function sendInstruction(array $instruction, int $expectedRuntime = 60): void
+    private function sendInstruction(array $instruction, int $expectedRuntime = 60): void
     {
         try {
             $this->logger->info(sprintf('dispatcher: selecting worker for type %s', $instruction['type']));

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use const INF;
 
 final class ProbeDispatcherCommand extends Command
 {
@@ -147,6 +148,14 @@ final class ProbeDispatcherCommand extends Command
             ]);
         });
 
+        Loop::addPeriodicTimer(1, function () {
+            $this->statsManager->addWorkerStats(
+                $this->workerManager->getTotalWorkers(),
+                $this->workerManager->getAvailableWorkers(),
+                $this->workerManager->getInUseWorkerTypes()
+            );
+        });
+
         $this->loop->addPeriodicTimer(1, function () {
             $now = time();
 
@@ -172,12 +181,6 @@ final class ProbeDispatcherCommand extends Command
                     }
                 }
             }
-
-            $this->statsManager->addWorkerStats(
-                $this->workerManager->getTotalWorkers(),
-                $this->workerManager->getAvailableWorkers(),
-                $this->workerManager->getInUseWorkerTypes()
-            );
         });
 
         $this->loop->addPeriodicTimer(0.1, function () {

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -22,11 +22,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 use function time;
-use const INF;
 
 final class ProbeDispatcherCommand extends Command
 {
-    private int $numberOfQueues = 10;
+    public const DEFAULT_NUMBER_OF_QUEUES = 10;
 
     /**
      * @var Queue[]
@@ -95,10 +94,10 @@ final class ProbeDispatcherCommand extends Command
         $this->workerManager->initialize(
             (int) $input->getOption('workers'),
             (int) $input->getOption('maximum-workers'),
-            $this->numberOfQueues
+            self::DEFAULT_NUMBER_OF_QUEUES
         );
 
-        for ($i = 0; $i < $this->numberOfQueues; ++$i) {
+        for ($i = 0; $i < self::DEFAULT_NUMBER_OF_QUEUES; ++$i) {
             $this->queues[$i] = new Queue(
                 $this->workerManager,
                 $this->statsManager,
@@ -271,7 +270,7 @@ final class ProbeDispatcherCommand extends Command
 
                 $items = $this->expandProbeResult($contents);
                 foreach ($items as $key => $item) {
-                    $queue = $this->queues[$key % $this->numberOfQueues];
+                    $queue = $this->queues[$key % self::DEFAULT_NUMBER_OF_QUEUES];
                     $queue->enqueue($item);
                 }
                 break;

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -188,14 +188,10 @@ final class ProbeDispatcherCommand extends Command
         });
 
         if ($this->maxRuntime > 0) {
-            $this->logger->info('Running for '.$this->maxRuntime.' seconds');
-            $this->loop->addTimer(
-                $this->maxRuntime,
-                function () use ($output) {
-                    $output->writeln('Max runtime reached');
-                    $this->loop->stop();
-                }
-            );
+            Loop::addTimer($this->maxRuntime, function () use ($output) {
+                $output->writeln('Max runtime reached');
+                Loop::stop();
+            });
         }
 
         $this->loop->run();

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -160,12 +160,14 @@ final class ProbeDispatcherCommand extends Command
             $this->workerManager->loop();
         });
 
-        $this->loop->addPeriodicTimer(1, function () {
-            $now = time();
-
+        Loop::addPeriodicTimer(1, function () {
             foreach ($this->queues as $queue) {
                 $queue->loop();
             }
+        });
+
+        $this->loop->addPeriodicTimer(1, function () {
+            $now = time();
 
             foreach ($this->configuration->getProbes() as $probe) {
                 $ready = 0 === $now % $probe->getStep();

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -16,7 +16,6 @@ use App\Slave\Worker\WorkerManager;
 use Exception;
 use Psr\Log\LoggerInterface;
 use React\EventLoop\Loop;
-use React\EventLoop\LoopInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -25,8 +25,8 @@ use function time;
 
 final class ProbeDispatcherCommand extends Command
 {
-    public const DEFAULT_NUMBER_OF_QUEUES = 10;
-    public const DEVICES_PER_WORKER = 250;
+    private const DEFAULT_NUMBER_OF_QUEUES = 10;
+    private const DEVICES_PER_WORKER = 250;
 
     /**
      * @var Queue[]

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -42,7 +42,6 @@ final class ProbeDispatcherCommand extends Command
      * indicate an infinitely running process.
      */
     private int $maxRuntime = 0;
-    private LoopInterface $loop;
     private WorkerManager $workerManager;
     private StatsManager $statsManager;
     private int $devicesPerWorker = 250;
@@ -128,8 +127,6 @@ final class ProbeDispatcherCommand extends Command
         $this->logger->info('Slave name is '.$_ENV['SLAVE_NAME']);
         $this->logger->info('Slave url is '.$_ENV['SLAVE_URL']);
         $this->logger->info('Random factor is '.$this->randomFactor);
-
-        $this->loop = Loop::get();
 
         Loop::addPeriodicTimer(120, function () {
             $this->sendInstruction([

--- a/src/Slave/Command/ProbeDispatcherCommand.php
+++ b/src/Slave/Command/ProbeDispatcherCommand.php
@@ -45,7 +45,6 @@ final class ProbeDispatcherCommand extends Command
     private WorkerManager $workerManager;
     private StatsManager $statsManager;
     private int $devicesPerWorker = 250;
-    private int $randomFactor = 0;
 
     public function __construct(LoggerInterface $logger, WorkerManager $workerManager, StatsManager $statsManager)
     {
@@ -87,7 +86,6 @@ final class ProbeDispatcherCommand extends Command
     private function setUp(InputInterface $input)
     {
         $this->maxRuntime = (int) $input->getOption('max-runtime');
-        $this->randomFactor = random_int(0, 119);
 
         foreach (['SLAVE_NAME', 'SLAVE_URL'] as $item) {
             if (!isset($_ENV[$item])) {
@@ -126,7 +124,6 @@ final class ProbeDispatcherCommand extends Command
         $this->logger->info('Fireping Dispatcher Started.');
         $this->logger->info('Slave name is '.$_ENV['SLAVE_NAME']);
         $this->logger->info('Slave url is '.$_ENV['SLAVE_URL']);
-        $this->logger->info('Random factor is '.$this->randomFactor);
 
         Loop::addPeriodicTimer(120, function () {
             $this->sendInstruction([

--- a/src/Slave/Command/ProbeWorkerCommand.php
+++ b/src/Slave/Command/ProbeWorkerCommand.php
@@ -10,7 +10,7 @@ use App\Slave\Task\PublishStatistics;
 use App\Slave\Task\TaskFactory;
 use Exception;
 use Psr\Log\LoggerInterface;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Stream\ReadableResourceStream;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -49,7 +49,7 @@ final class ProbeWorkerCommand extends Command
     {
         $this->output = $output;
 
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $read = new ReadableResourceStream(STDIN, $loop);
 

--- a/src/Slave/Command/ProbeWorkerCommand.php
+++ b/src/Slave/Command/ProbeWorkerCommand.php
@@ -13,48 +13,24 @@ use Psr\Log\LoggerInterface;
 use React\EventLoop\Factory;
 use React\Stream\ReadableResourceStream;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Exception\InvalidArgumentException;
-use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ProbeWorkerCommand extends Command
+final class ProbeWorkerCommand extends Command
 {
-    /**
-     * @var OutputInterface
-     */
-    protected $output;
+    private OutputInterface $output;
+    private string $receiveBuffer = '';
+    private LoggerInterface $logger;
+    private TaskFactory $taskFactory;
 
-    /**
-     * @var string
-     */
-    protected $receiveBuffer;
-
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
-     * @var TaskFactory
-     */
-    private $taskFactory;
-
-    /**
-     * @throws LogicException
-     */
     public function __construct(LoggerInterface $logger, TaskFactory $taskFactory)
     {
+        parent::__construct();
         $this->logger = $logger;
         $this->taskFactory = $taskFactory;
-
-        parent::__construct();
     }
 
-    /**
-     * @throws InvalidArgumentException
-     */
     protected function configure(): void
     {
         $this
@@ -69,9 +45,6 @@ class ProbeWorkerCommand extends Command
             );
     }
 
-    /**
-     * @throws InvalidArgumentException
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
@@ -105,7 +78,7 @@ class ProbeWorkerCommand extends Command
     /**
      * @throws \LogicException
      */
-    protected function process(array $data)
+    private function process(array $data)
     {
         $startedAt = time();
         $this->logger->info(sprintf('worker %d has begun processing at %d', getmypid(), $startedAt));
@@ -193,7 +166,7 @@ class ProbeWorkerCommand extends Command
      * @param array $headers
      * @param array|string $contents
      */
-    protected function sendResponse(string $type, int $status, $contents, array $headers = []): void
+    private function sendResponse(string $type, int $status, $contents, array $headers = []): void
     {
         $pid = getmypid();
 


### PR DESCRIPTION
This PR aims to clean up the dispatcher and worker code a little bit by adding typehints, removing unnecessary codeblocks, dealing with some deprecations, etc.

Primarily, I've removed a couple unnecessary class properties, made the class final because we don't intend for it to be extended, promoted some class properties to private constants and refactored the deprecated Factory class away in favour of the static Loop methods.