### PR TITLE
chore: add config.allow-plugins.symfony/flex:true to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,10 @@
     },
     "config": {
         "sort-packages": true,
-        "process-timeout": 0
+        "process-timeout": 0,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "conflict": {
         "symfony/symfony": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -3696,12 +3696,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -10928,5 +10928,5 @@
         "ext-rrd": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
This is a new feature of composer. It was added by default when I did "composer install" on my local machine, so it should probably get added. See: https://getcomposer.org/doc/06-config.md#allow-plugins.