### PR TITLE
Discard "duplicate for" messages

### DIFF
--- a/src/Slave/OutputFormatter/PingOutputFormatter.php
+++ b/src/Slave/OutputFormatter/PingOutputFormatter.php
@@ -19,7 +19,18 @@ class PingOutputFormatter implements OutputFormatterInterface
 
     private function parseInput(string $input): array
     {
+        // TODO: This is indicative of an issue, but unfortunately I can no longer recall what prompted this.
+        //       We should probably capture this input and send it to the master in some way to create alerts.
         if (false === strpos($input, ':')) {
+            return [];
+        }
+        
+        // TODO: These should not just be silently discarded.
+        //       This is indicative of an issue, and the AlertDestination of the Device should be notified.
+        //       Note: we should probably make it configurable to notify for these issues or not.
+        //       Note: for this type of error, the left-hand side of the colon still contains the IP address,
+        //             making it possible to create alerts for it.
+        if (false !== strpos($input, ': duplicate')) {
             return [];
         }
 


### PR DESCRIPTION
This solves a bug that would cut off the results of the last X results, where X is the number of "duplicate for" messages emitted by fping. This isn't a permanent fix, but should prove good enough until we can get a proper fix for this.

This resolves #805 