### PR TITLE
Allow client page size override

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -1,4 +1,9 @@
 api_platform:
+    defaults:
+        pagination_client_items_per_page: true
+    collection:
+        pagination:
+            items_per_page_parameter_name: itemsPerPage # Default value
     mapping:
         paths: ['%kernel.project_dir%/src/Entity']
     patch_formats:


### PR DESCRIPTION
This allows api clients to override the number of items on a page