### PR TITLE
Add Discord alert destination

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -44,6 +44,10 @@ services:
         arguments: ["@eight_points_guzzle.client.alert", "@monolog.logger"]
         public: true
 
+    App\AlertDestination\Discord:
+        arguments: ["@eight_points_guzzle.client.alert", "@monolog.logger"]
+        public: true
+
     App\AlertDestination\Mail:
         arguments: ["@swiftmailer.mailer.default", "@monolog.logger", "@twig", "%env(MAILER_FROM)%"]
         public: true

--- a/src/AlertDestination/AlertDestinationInterface.php
+++ b/src/AlertDestination/AlertDestinationInterface.php
@@ -13,9 +13,9 @@ abstract class AlertDestinationInterface
     protected function getAlertMessage(Alert $alert)
     {
         if ($alert->getActive()) {
-            return $alert->getAlertRule()->getMessageDown().': '.$alert->getDevice()->getName().' from '.$alert->getSlaveGroup()->getName();
+            return '🔴 '.$alert->getAlertRule()->getMessageDown().': '.$alert->getDevice()->getName().' from '.$alert->getSlaveGroup()->getName();
         } else {
-            return $alert->getAlertRule()->getMessageUp().': '.$alert->getDevice()->getName().' from '.$alert->getSlaveGroup()->getName();
+            return '🟢 '.$alert->getAlertRule()->getMessageUp().': '.$alert->getDevice()->getName().' from '.$alert->getSlaveGroup()->getName();
         }
     }
 

--- a/src/AlertDestination/AlertDestinationInterface.php
+++ b/src/AlertDestination/AlertDestinationInterface.php
@@ -13,9 +13,9 @@ abstract class AlertDestinationInterface
     protected function getAlertMessage(Alert $alert)
     {
         if ($alert->getActive()) {
-            return '🔴 '.$alert->getAlertRule()->getMessageDown().': '.$alert->getDevice()->getName().' from '.$alert->getSlaveGroup()->getName();
+            return $alert->getAlertRule()->getMessageDown().': '.$alert->getDevice()->getName().' from '.$alert->getSlaveGroup()->getName();
         } else {
-            return '🟢 '.$alert->getAlertRule()->getMessageUp().': '.$alert->getDevice()->getName().' from '.$alert->getSlaveGroup()->getName();
+            return $alert->getAlertRule()->getMessageUp().': '.$alert->getDevice()->getName().' from '.$alert->getSlaveGroup()->getName();
         }
     }
 

--- a/src/AlertDestination/Discord.php
+++ b/src/AlertDestination/Discord.php
@@ -28,15 +28,15 @@ class Discord extends AlertDestinationInterface
 
     public function trigger(Alert $alert)
     {
-        return $this->send($alert, 16728374, '🔴');
+        return $this->send($alert, 16728374);
     }
 
     public function clear(Alert $alert)
     {
-        return $this->send($alert, 3066944, '🟢');
+        return $this->send($alert, 3066944);
     }
 
-    protected function send(Alert $alert, int $color, string $dot)
+    protected function send(Alert $alert, int $color)
     {
         if (!$this->url) {
             return false;
@@ -46,7 +46,7 @@ class Discord extends AlertDestinationInterface
                 'username' => 'fireping',
                 'embeds' => [
                     [
-                        'description' => $dot.' '.$this->getAlertMessage($alert),
+                        'description' => $this->getAlertMessage($alert),
                         'color' => $color,
                     ],
                 ],

--- a/src/AlertDestination/Discord.php
+++ b/src/AlertDestination/Discord.php
@@ -28,15 +28,15 @@ class Discord extends AlertDestinationInterface
 
     public function trigger(Alert $alert)
     {
-        return $this->send($alert, 16728374);
+        return $this->send($alert, 16728374, '🔴');
     }
 
     public function clear(Alert $alert)
     {
-        return $this->send($alert, 3066944);
+        return $this->send($alert, 3066944, '🟢');
     }
 
-    protected function send(Alert $alert, int $color)
+    protected function send(Alert $alert, int $color, string $dot)
     {
         if (!$this->url) {
             return false;
@@ -46,7 +46,7 @@ class Discord extends AlertDestinationInterface
                 'username' => 'fireping',
                 'embeds' => [
                     [
-                        'description' => $this->getAlertMessage($alert),
+                        'description' => $dot.' '.$this->getAlertMessage($alert),
                         'color' => $color,
                     ],
                 ],

--- a/src/AlertDestination/Discord.php
+++ b/src/AlertDestination/Discord.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\AlertDestination;
+
+use App\Entity\Alert;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Psr\Log\LoggerInterface;
+
+class Discord extends AlertDestinationInterface
+{
+    protected $client;
+    protected $url;
+    protected $logger;
+
+    public function __construct(Client $client, LoggerInterface $logger)
+    {
+        $this->client = $client;
+        $this->logger = $logger;
+    }
+
+    public function setParameters(array $parameters): void
+    {
+        if ($parameters && isset($parameters['url'])) {
+            $this->url = $parameters['url'];
+        }
+    }
+
+    public function trigger(Alert $alert)
+    {
+        return $this->send($alert, 16728374);
+    }
+
+    public function clear(Alert $alert)
+    {
+        return $this->send($alert, 3066944);
+    }
+
+    protected function send(Alert $alert, int $color)
+    {
+        if (!$this->url) {
+            return false;
+        }
+        try {
+            $data = [
+                'username' => 'fireping',
+                'embeds' => [
+                    [
+                        'description' => $this->getAlertMessage($alert),
+                        'color' => $color,
+                    ],
+                ],
+            ];
+            $this->client->post($this->url, [RequestOptions::JSON => $data]);
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a new `discord` alert destination type that posts alerts to a Discord channel webhook as native embeds — red on trigger, green on clear.

Parameters: `url` (the Discord webhook URL). Unlike Slack, Discord webhooks are bound to a single channel, so no channel parameter is needed.

## Why

Slack's free tier has become impractical for us; Discord webhooks are a free, simple replacement. The destination follows the same structure as the existing Slack/Gotify destinations and is picked up automatically by `AlertDestinationFactory`.

## Testing

- Payload format verified against a live Discord webhook (both trigger and clear render correctly).
- `php -l` clean; no schema changes needed (destination `type` is a plain string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)