### PR TITLE
Keep CA certificates current in the image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PHP_MEMORY_LIMIT="128M"
 ADD . /app
 
 RUN apt-get update
-RUN apt-get install -y fping zip git rrdtool librrd-dev procps dos2unix
+RUN apt-get install -y fping zip git rrdtool librrd-dev procps dos2unix ca-certificates && update-ca-certificates
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Adds `ca-certificates` (with `update-ca-certificates`) to the image build, so every build ships a current CA trust store.

## Why

The published Docker Hub image is old enough that its CA store doesn't trust newer roots. We hit this in production: after our wildcard certificate was renewed onto the Sectigo Public Server Authentication Root R46 chain, slaves running the published image could no longer talk to the master over HTTPS — every publish failed with `cURL error 60: SSL certificate problem: unable to get local issuer certificate`, and monitoring silently stopped.

With this line any rebuild picks up the current trust store regardless of base image age. A rebuild/republish of the Docker Hub image would fix it for everyone running the published image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)